### PR TITLE
Add URL-based database connection screen

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+SqlViewer

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/app/src/main/java/com/amnesiawho/sqlviewer/MainActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/MainActivity.java
@@ -1,12 +1,9 @@
 package com.amnesiawho.sqlviewer;
 
 import android.os.Bundle;
-import android.view.View;
-import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
-import android.widget.Spinner;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.activity.EdgeToEdge;
@@ -21,11 +18,9 @@ import com.amnesiawho.sqlviewer.core.exception.GlobalExceptionHandler;
 import com.amnesiawho.sqlviewer.data.db.DatabaseManager;
 import com.amnesiawho.sqlviewer.data.db.DbEngineType;
 import com.amnesiawho.sqlviewer.data.db.TableData;
+import com.amnesiawho.sqlviewer.data.db.UrlEngineResolver;
 import com.amnesiawho.sqlviewer.ui.table.TableAdapter;
 import com.google.android.material.button.MaterialButtonToggleGroup;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -33,7 +28,10 @@ public class MainActivity extends AppCompatActivity {
     private TableAdapter tableAdapter;
     private MaterialButtonToggleGroup limitToggleGroup;
     private EditText tableNameInput;
-    private Spinner engineSpinner;
+    private EditText urlInput;
+    private TextView engineLabel;
+    private Button connectButton;
+    private boolean isConnected = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -49,16 +47,15 @@ public class MainActivity extends AppCompatActivity {
         // Инициализация инфраструктуры
         databaseManager = new DatabaseManager(this);
         setupViews();
-        setupEngineSpinner();
+        setupConnectionBlock();
         setupLimitSelector();
-
-        // Загружаем данные сразу, чтобы пользователь видел демо-таблицу
-        loadTable();
     }
 
     private void setupViews() {
         tableNameInput = findViewById(R.id.tableNameInput);
-        engineSpinner = findViewById(R.id.engineSpinner);
+        urlInput = findViewById(R.id.urlInput);
+        engineLabel = findViewById(R.id.engineLabel);
+        connectButton = findViewById(R.id.connectButton);
         limitToggleGroup = findViewById(R.id.limitToggleGroup);
         RecyclerView tableRecycler = findViewById(R.id.tableRecycler);
         Button loadButton = findViewById(R.id.loadButton);
@@ -71,28 +68,10 @@ public class MainActivity extends AppCompatActivity {
         loadButton.setOnClickListener(v -> loadTable());
     }
 
-    private void setupEngineSpinner() {
-        // Собираем список заголовков и связываем с перечислением
-        List<String> titles = new ArrayList<>();
-        for (DbEngineType type : DbEngineType.values()) {
-            titles.add(type.getTitle());
-        }
-        ArrayAdapter<String> adapter = new ArrayAdapter<>(this, R.layout.item_spinner_dark, titles);
-        adapter.setDropDownViewResource(R.layout.item_spinner_dark);
-        engineSpinner.setAdapter(adapter);
-        engineSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                DbEngineType selected = DbEngineType.values()[position];
-                databaseManager.switchEngine(selected);
-                loadTable();
-            }
-
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-                // Ничего не делаем
-            }
-        });
+    private void setupConnectionBlock() {
+        connectButton.setOnClickListener(v -> attemptConnection());
+        urlInput.setText("sqlite://demo");
+        updateEngineLabel(null);
     }
 
     private void setupLimitSelector() {
@@ -120,6 +99,10 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void loadTable() {
+        if (!isConnected) {
+            Toast.makeText(this, "Сначала подключитесь к базе данных", Toast.LENGTH_SHORT).show();
+            return;
+        }
         String tableName = tableNameInput.getText().toString();
         int limit = getSelectedLimit();
         try {
@@ -131,6 +114,33 @@ public class MainActivity extends AppCompatActivity {
         } catch (Exception e) {
             // Пробрасываем ошибку в общий обработчик
             GlobalExceptionHandler.reportHandled(this, e);
+        }
+    }
+
+    private void attemptConnection() {
+        String url = urlInput.getText().toString().trim();
+        if (url.isEmpty()) {
+            Toast.makeText(this, "Введите URL подключения", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        try {
+            DbEngineType engineType = UrlEngineResolver.resolve(url);
+            databaseManager.switchEngine(engineType);
+            isConnected = true;
+            updateEngineLabel(engineType);
+            Toast.makeText(this, "Подключение успешно: " + engineType.getTitle(), Toast.LENGTH_SHORT).show();
+        } catch (IllegalArgumentException ex) {
+            isConnected = false;
+            updateEngineLabel(null);
+            Toast.makeText(this, ex.getMessage(), Toast.LENGTH_LONG).show();
+        }
+    }
+
+    private void updateEngineLabel(DbEngineType engineType) {
+        if (engineType == null) {
+            engineLabel.setText("Движок будет определён автоматически");
+        } else {
+            engineLabel.setText("Определён движок: " + engineType.getTitle());
         }
     }
 }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/MainActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/MainActivity.java
@@ -1,6 +1,7 @@
 package com.amnesiawho.sqlviewer;
 
 import android.os.Bundle;
+import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -17,21 +18,37 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.amnesiawho.sqlviewer.core.exception.GlobalExceptionHandler;
 import com.amnesiawho.sqlviewer.data.db.DatabaseManager;
 import com.amnesiawho.sqlviewer.data.db.DbEngineType;
+import com.amnesiawho.sqlviewer.data.db.SchemaInfo;
 import com.amnesiawho.sqlviewer.data.db.TableData;
 import com.amnesiawho.sqlviewer.data.db.UrlEngineResolver;
+import com.amnesiawho.sqlviewer.ui.schema.SchemaAdapter;
 import com.amnesiawho.sqlviewer.ui.table.TableAdapter;
+import com.amnesiawho.sqlviewer.ui.table.TableListAdapter;
 import com.google.android.material.button.MaterialButtonToggleGroup;
+
+import java.util.List;
 
 public class MainActivity extends AppCompatActivity {
 
     private DatabaseManager databaseManager;
     private TableAdapter tableAdapter;
+    private TableListAdapter tableListAdapter;
+    private SchemaAdapter schemaAdapter;
     private MaterialButtonToggleGroup limitToggleGroup;
-    private EditText tableNameInput;
     private EditText urlInput;
     private TextView engineLabel;
+    private TextView selectedSchemaLabel;
+    private TextView schemaAccessLabel;
+    private TextView selectedTableLabel;
     private Button connectButton;
+    private Button addTableButton;
+    private View schemaCard;
+    private View tableSelectorCard;
+
     private boolean isConnected = false;
+    private String selectedSchema = null;
+    private String selectedTable = null;
+    private boolean selectedSchemaEditable = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -52,26 +69,44 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void setupViews() {
-        tableNameInput = findViewById(R.id.tableNameInput);
         urlInput = findViewById(R.id.urlInput);
         engineLabel = findViewById(R.id.engineLabel);
         connectButton = findViewById(R.id.connectButton);
         limitToggleGroup = findViewById(R.id.limitToggleGroup);
+        selectedSchemaLabel = findViewById(R.id.selectedSchemaLabel);
+        schemaAccessLabel = findViewById(R.id.schemaAccessLabel);
+        selectedTableLabel = findViewById(R.id.selectedTableLabel);
+        addTableButton = findViewById(R.id.addTableButton);
+        schemaCard = findViewById(R.id.schemaCard);
+        tableSelectorCard = findViewById(R.id.tableSelectorCard);
         RecyclerView tableRecycler = findViewById(R.id.tableRecycler);
+        RecyclerView schemaRecyclerView = findViewById(R.id.schemaRecycler);
+        RecyclerView tableListRecyclerView = findViewById(R.id.tableListRecycler);
         Button loadButton = findViewById(R.id.loadButton);
 
         tableAdapter = new TableAdapter(this);
         tableRecycler.setLayoutManager(new LinearLayoutManager(this));
         tableRecycler.setAdapter(tableAdapter);
 
+        schemaAdapter = new SchemaAdapter(this::onSchemaSelected);
+        schemaRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        schemaRecyclerView.setAdapter(schemaAdapter);
+
+        tableListAdapter = new TableListAdapter(this::onTableSelected);
+        tableListRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        tableListRecyclerView.setAdapter(tableListAdapter);
+
         // Кнопка загрузки данных
         loadButton.setOnClickListener(v -> loadTable());
+        addTableButton.setOnClickListener(v -> handleAddTable());
     }
 
     private void setupConnectionBlock() {
         connectButton.setOnClickListener(v -> attemptConnection());
         urlInput.setText("sqlite://demo");
         updateEngineLabel(null);
+        schemaCard.setVisibility(View.GONE);
+        tableSelectorCard.setVisibility(View.GONE);
     }
 
     private void setupLimitSelector() {
@@ -103,10 +138,17 @@ public class MainActivity extends AppCompatActivity {
             Toast.makeText(this, "Сначала подключитесь к базе данных", Toast.LENGTH_SHORT).show();
             return;
         }
-        String tableName = tableNameInput.getText().toString();
+        if (selectedSchema == null) {
+            Toast.makeText(this, "Выберите схему", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        if (selectedTable == null || selectedTable.isEmpty()) {
+            Toast.makeText(this, "Выберите таблицу", Toast.LENGTH_SHORT).show();
+            return;
+        }
         int limit = getSelectedLimit();
         try {
-            TableData data = databaseManager.readTable(tableName, limit);
+            TableData data = databaseManager.readTable(selectedSchema, selectedTable, limit);
             tableAdapter.setData(data);
             if (data.isEmpty()) {
                 Toast.makeText(this, "Данных нет или таблица пуста", Toast.LENGTH_SHORT).show();
@@ -115,6 +157,81 @@ public class MainActivity extends AppCompatActivity {
             // Пробрасываем ошибку в общий обработчик
             GlobalExceptionHandler.reportHandled(this, e);
         }
+    }
+
+    private void loadSchemas() {
+        try {
+            List<SchemaInfo> schemas = databaseManager.listSchemas();
+            schemaAdapter.setItems(schemas);
+            schemaAdapter.setSelectedSchema(null);
+            schemaCard.setVisibility(View.VISIBLE);
+            tableSelectorCard.setVisibility(View.GONE);
+            selectedSchema = null;
+            selectedTable = null;
+            selectedSchemaEditable = false;
+            selectedSchemaLabel.setText("Выберите схему");
+            schemaAccessLabel.setText("Статус схемы не выбран");
+            selectedTableLabel.setText("Таблица не выбрана");
+            updateEditingUi();
+        } catch (Exception e) {
+            schemaCard.setVisibility(View.GONE);
+            tableSelectorCard.setVisibility(View.GONE);
+            GlobalExceptionHandler.reportHandled(this, e);
+        }
+    }
+
+    private void onSchemaSelected(SchemaInfo schemaInfo) {
+        selectedSchema = schemaInfo.getName();
+        selectedSchemaEditable = schemaInfo.isEditable();
+        selectedTable = null;
+        schemaAdapter.setSelectedSchema(selectedSchema);
+        selectedSchemaLabel.setText("Схема: " + selectedSchema);
+        selectedTableLabel.setText("Таблица не выбрана");
+        updateEditingUi();
+        loadTablesForSchema(selectedSchema);
+    }
+
+    private void loadTablesForSchema(String schema) {
+        try {
+            List<String> tables = databaseManager.listTables(schema);
+            tableListAdapter.setItems(tables);
+            tableSelectorCard.setVisibility(View.VISIBLE);
+        } catch (Exception e) {
+            tableSelectorCard.setVisibility(View.GONE);
+            GlobalExceptionHandler.reportHandled(this, e);
+        }
+    }
+
+    private void onTableSelected(String tableName) {
+        selectedTable = tableName;
+        selectedTableLabel.setText("Выбрана таблица: " + tableName);
+    }
+
+    private void updateEditingUi() {
+        if (selectedSchema == null) {
+            schemaAccessLabel.setText("Статус схемы не выбран");
+            schemaAccessLabel.setTextColor(getColor(R.color.supabase_on_surface));
+            addTableButton.setVisibility(View.GONE);
+            return;
+        }
+
+        if (selectedSchemaEditable) {
+            schemaAccessLabel.setText("Редактирование доступно");
+            addTableButton.setVisibility(View.VISIBLE);
+            schemaAccessLabel.setTextColor(getColor(R.color.supabase_on_surface));
+        } else {
+            schemaAccessLabel.setText("Только чтение");
+            addTableButton.setVisibility(View.GONE);
+            schemaAccessLabel.setTextColor(getColor(R.color.supabase_warning));
+        }
+    }
+
+    private void handleAddTable() {
+        if (!selectedSchemaEditable) {
+            Toast.makeText(this, "Редактирование недоступно для выбранной схемы", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        Toast.makeText(this, "Функционал добавления таблиц будет доступен позже", Toast.LENGTH_SHORT).show();
     }
 
     private void attemptConnection() {
@@ -128,10 +245,13 @@ public class MainActivity extends AppCompatActivity {
             databaseManager.switchEngine(engineType);
             isConnected = true;
             updateEngineLabel(engineType);
+            loadSchemas();
             Toast.makeText(this, "Подключение успешно: " + engineType.getTitle(), Toast.LENGTH_SHORT).show();
         } catch (IllegalArgumentException ex) {
             isConnected = false;
             updateEngineLabel(null);
+            schemaCard.setVisibility(View.GONE);
+            tableSelectorCard.setVisibility(View.GONE);
             Toast.makeText(this, ex.getMessage(), Toast.LENGTH_LONG).show();
         }
     }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseEngine.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseEngine.java
@@ -2,6 +2,8 @@ package com.amnesiawho.sqlviewer.data.db;
 
 import android.content.ContentValues;
 
+import java.util.List;
+
 /**
  * Базовый контракт CRUD-операций для разных движков БД.
  */
@@ -14,10 +16,21 @@ public interface DatabaseEngine {
     /**
      * Чтение таблицы с ограничением по строкам.
      *
+     * @param schema    имя схемы или пространства, где находится таблица
      * @param tableName имя таблицы
      * @param limit     лимит строк, -1 если лимита нет
      */
-    TableData readTable(String tableName, int limit) throws Exception;
+    TableData readTable(String schema, String tableName, int limit) throws Exception;
+
+    /**
+     * Список доступных схем/пространств имен.
+     */
+    List<SchemaInfo> listSchemas() throws Exception;
+
+    /**
+     * Возвращает список таблиц в выбранной схеме.
+     */
+    List<String> listTables(String schema) throws Exception;
 
     long insert(String tableName, ContentValues values) throws Exception;
 

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseManager.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseManager.java
@@ -38,8 +38,16 @@ public class DatabaseManager {
         }
     }
 
-    public TableData readTable(String tableName, int limit) throws Exception {
-        return currentEngine.readTable(tableName, limit);
+    public TableData readTable(String schema, String tableName, int limit) throws Exception {
+        return currentEngine.readTable(schema, tableName, limit);
+    }
+
+    public java.util.List<SchemaInfo> listSchemas() throws Exception {
+        return currentEngine.listSchemas();
+    }
+
+    public java.util.List<String> listTables(String schema) throws Exception {
+        return currentEngine.listTables(schema);
     }
 
     public DbEngineType getCurrentType() {

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SQLiteEngine.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SQLiteEngine.java
@@ -67,7 +67,7 @@ public class SQLiteEngine extends SQLiteOpenHelper implements DatabaseEngine {
     }
 
     @Override
-    public TableData readTable(String tableName, int limit) {
+    public TableData readTable(String schema, String tableName, int limit) {
         List<String> columns = new ArrayList<>();
         List<List<String>> rows = new ArrayList<>();
 
@@ -100,6 +100,60 @@ public class SQLiteEngine extends SQLiteOpenHelper implements DatabaseEngine {
             }
         }
         return new TableData(columns, rows);
+    }
+
+    @Override
+    public List<SchemaInfo> listSchemas() {
+        List<SchemaInfo> schemas = new ArrayList<>();
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor cursor = db.rawQuery("PRAGMA database_list;", null);
+        try {
+            int nameIndex = cursor.getColumnIndexOrThrow("name");
+            while (cursor.moveToNext()) {
+                String name = cursor.getString(nameIndex);
+                boolean editable = "main".equalsIgnoreCase(name);
+                schemas.add(new SchemaInfo(name, editable));
+            }
+        } finally {
+            cursor.close();
+        }
+
+        if (schemas.isEmpty()) {
+            schemas.add(new SchemaInfo("main", true));
+            schemas.add(new SchemaInfo("temp", false));
+        }
+        return schemas;
+    }
+
+    @Override
+    public List<String> listTables(String schema) {
+        List<String> tables = new ArrayList<>();
+        SQLiteDatabase db = getReadableDatabase();
+        String masterTable;
+        if (schema == null || schema.isEmpty()) {
+            masterTable = "sqlite_master";
+        } else if ("temp".equalsIgnoreCase(schema)) {
+            masterTable = "sqlite_temp_master";
+        } else {
+            masterTable = schema + ".sqlite_master";
+        }
+        Cursor cursor = db.rawQuery(
+                "SELECT name FROM " + masterTable + " WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name;",
+                null
+        );
+        try {
+            int nameIndex = cursor.getColumnIndexOrThrow("name");
+            while (cursor.moveToNext()) {
+                tables.add(cursor.getString(nameIndex));
+            }
+        } finally {
+            cursor.close();
+        }
+
+        if (tables.isEmpty()) {
+            tables.add(DEMO_TABLE);
+        }
+        return tables;
     }
 
     @Override

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SchemaInfo.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SchemaInfo.java
@@ -1,0 +1,22 @@
+package com.amnesiawho.sqlviewer.data.db;
+
+/**
+ * Модель описания схемы/пространства имён.
+ */
+public class SchemaInfo {
+    private final String name;
+    private final boolean editable;
+
+    public SchemaInfo(String name, boolean editable) {
+        this.name = name;
+        this.editable = editable;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isEditable() {
+        return editable;
+    }
+}

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/StubEngine.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/StubEngine.java
@@ -25,12 +25,33 @@ public class StubEngine implements DatabaseEngine {
     }
 
     @Override
-    public TableData readTable(String tableName, int limit) {
+    public TableData readTable(String schema, String tableName, int limit) {
         // Возвращаем информативную таблицу, чтобы пользователь понимал, что нужно подключить драйвер.
         List<String> columns = Collections.singletonList("Движок " + type.getTitle());
         List<List<String>> rows = new ArrayList<>();
         rows.add(Collections.singletonList("Добавьте драйвер и реальное подключение, чтобы читать таблицу '" + tableName + "'."));
         return new TableData(columns, rows);
+    }
+
+    @Override
+    public List<SchemaInfo> listSchemas() {
+        List<SchemaInfo> schemas = new ArrayList<>();
+        schemas.add(new SchemaInfo("public", false));
+        schemas.add(new SchemaInfo("sandbox", true));
+        schemas.add(new SchemaInfo("analytics", false));
+        return schemas;
+    }
+
+    @Override
+    public List<String> listTables(String schema) {
+        if ("sandbox".equalsIgnoreCase(schema)) {
+            return Collections.singletonList("draft_table");
+        }
+        List<String> tables = new ArrayList<>();
+        tables.add("users");
+        tables.add("events");
+        tables.add("metrics");
+        return tables;
     }
 
     @Override

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/UrlEngineResolver.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/UrlEngineResolver.java
@@ -1,0 +1,60 @@
+package com.amnesiawho.sqlviewer.data.db;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+
+/**
+ * Утилита для определения движка базы данных по URL.
+ */
+public final class UrlEngineResolver {
+
+    private UrlEngineResolver() {
+    }
+
+    /**
+     * Определяет движок по схеме URL. Поддерживает JDBC префикс.
+     *
+     * @param url строка подключения
+     * @return тип движка
+     * @throws IllegalArgumentException если схема не распознана или URL некорректен
+     */
+    public static DbEngineType resolve(String url) {
+        if (url == null || url.trim().isEmpty()) {
+            throw new IllegalArgumentException("URL подключения не должен быть пустым");
+        }
+        String normalized = url.trim();
+        if (normalized.toLowerCase(Locale.ROOT).startsWith("jdbc:")) {
+            normalized = normalized.substring(5);
+        }
+        URI uri;
+        try {
+            uri = new URI(normalized);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Некорректный формат URL: " + e.getMessage());
+        }
+
+        String scheme = uri.getScheme();
+        if (scheme == null || scheme.isEmpty()) {
+            throw new IllegalArgumentException("URL должен содержать схему (например, sqlite, postgres)");
+        }
+
+        switch (scheme.toLowerCase(Locale.ROOT)) {
+            case "sqlite":
+                return DbEngineType.SQLITE;
+            case "mysql":
+            case "mariadb":
+                return DbEngineType.MYSQL;
+            case "postgres":
+            case "postgresql":
+                return DbEngineType.POSTGRESQL;
+            case "sqlserver":
+            case "mssql":
+                return DbEngineType.SQLSERVER;
+            case "oracle":
+                return DbEngineType.ORACLE;
+            default:
+                throw new IllegalArgumentException("Неизвестная схема URL: " + scheme);
+        }
+    }
+}

--- a/app/src/main/java/com/amnesiawho/sqlviewer/ui/schema/SchemaAdapter.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/ui/schema/SchemaAdapter.java
@@ -1,0 +1,95 @@
+package com.amnesiawho.sqlviewer.ui.schema;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.amnesiawho.sqlviewer.R;
+import com.amnesiawho.sqlviewer.data.db.SchemaInfo;
+import com.google.android.material.card.MaterialCardView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SchemaAdapter extends RecyclerView.Adapter<SchemaAdapter.SchemaViewHolder> {
+
+    public interface OnSchemaClickListener {
+        void onSchemaClick(SchemaInfo schemaInfo);
+    }
+
+    private final List<SchemaInfo> items = new ArrayList<>();
+    private final OnSchemaClickListener listener;
+    private String selectedSchema;
+
+    public SchemaAdapter(OnSchemaClickListener listener) {
+        this.listener = listener;
+    }
+
+    public void setItems(List<SchemaInfo> schemas) {
+        items.clear();
+        items.addAll(schemas);
+        notifyDataSetChanged();
+    }
+
+    public void setSelectedSchema(String schema) {
+        this.selectedSchema = schema;
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public SchemaViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_schema, parent, false);
+        return new SchemaViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull SchemaViewHolder holder, int position) {
+        SchemaInfo info = items.get(position);
+        holder.bind(info, info.getName().equals(selectedSchema), listener);
+    }
+
+    @Override
+    public int getItemCount() {
+        return items.size();
+    }
+
+    static class SchemaViewHolder extends RecyclerView.ViewHolder {
+
+        private final TextView nameView;
+        private final TextView modeView;
+        private final MaterialCardView cardView;
+
+        SchemaViewHolder(@NonNull View itemView) {
+            super(itemView);
+            cardView = (MaterialCardView) itemView;
+            nameView = itemView.findViewById(R.id.schemaName);
+            modeView = itemView.findViewById(R.id.schemaMode);
+        }
+
+        void bind(SchemaInfo info, boolean isSelected, OnSchemaClickListener listener) {
+            nameView.setText(info.getName());
+            modeView.setText(info.isEditable() ? "Редактируемая" : "Только чтение");
+
+            int strokeColor = ContextCompat.getColor(itemView.getContext(),
+                    isSelected ? R.color.supabase_primary : R.color.supabase_border);
+            int background = ContextCompat.getColor(itemView.getContext(),
+                    info.isEditable() ? R.color.supabase_surface : R.color.supabase_surface_high);
+
+            cardView.setStrokeColor(strokeColor);
+            cardView.setCardBackgroundColor(background);
+            cardView.setCardElevation(isSelected ? 6f : 2f);
+
+            int modeColor = ContextCompat.getColor(itemView.getContext(),
+                    info.isEditable() ? R.color.supabase_on_surface : R.color.supabase_warning);
+            modeView.setTextColor(modeColor);
+
+            itemView.setOnClickListener(v -> listener.onSchemaClick(info));
+        }
+    }
+}

--- a/app/src/main/java/com/amnesiawho/sqlviewer/ui/table/TableListAdapter.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/ui/table/TableListAdapter.java
@@ -1,0 +1,81 @@
+package com.amnesiawho.sqlviewer.ui.table;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.amnesiawho.sqlviewer.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TableListAdapter extends RecyclerView.Adapter<TableListAdapter.TableViewHolder> {
+
+    public interface OnTableClickListener {
+        void onTableClick(String tableName);
+    }
+
+    private final List<String> items = new ArrayList<>();
+    private final OnTableClickListener listener;
+    private String selectedTable;
+
+    public TableListAdapter(OnTableClickListener listener) {
+        this.listener = listener;
+    }
+
+    public void setItems(List<String> tables) {
+        items.clear();
+        items.addAll(tables);
+        selectedTable = null;
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public TableViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_table_entry, parent, false);
+        return new TableViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull TableViewHolder holder, int position) {
+        String tableName = items.get(position);
+        holder.bind(tableName, tableName.equals(selectedTable), listener, () -> {
+            selectedTable = tableName;
+            notifyDataSetChanged();
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        return items.size();
+    }
+
+    static class TableViewHolder extends RecyclerView.ViewHolder {
+
+        private final TextView nameView;
+        private final View container;
+
+        TableViewHolder(@NonNull View itemView) {
+            super(itemView);
+            container = itemView.findViewById(R.id.tableItemContainer);
+            nameView = itemView.findViewById(R.id.tableItemName);
+        }
+
+        void bind(String tableName, boolean isSelected, OnTableClickListener listener, Runnable onSelected) {
+            nameView.setText(tableName);
+            int background = ContextCompat.getColor(itemView.getContext(),
+                    isSelected ? R.color.supabase_surface_high : R.color.supabase_surface);
+            container.setBackgroundColor(background);
+            itemView.setOnClickListener(v -> {
+                onSelected.run();
+                listener.onTableClick(tableName);
+            });
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -44,26 +44,57 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Движок БД"
+                android:text="URL подключения"
                 android:textColor="@color/supabase_on_surface"
                 android:textStyle="bold" />
 
-            <Spinner
-                android:id="@+id/engineSpinner"
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/urlInputLayout"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:backgroundTint="@color/supabase_surface_high"
-                android:entries="@array/engine_titles"
-                android:popupBackground="@color/supabase_surface_high"
-                android:textColor="@color/supabase_on_surface"
-                android:prompt="Выберите движок"
-                android:textColorHighlight="@color/supabase_primary" />
+                android:hint="Например, postgres://host:5432/db"
+                android:textColorHint="@color/supabase_on_surface"
+                app:boxStrokeColor="@color/supabase_border"
+                app:boxStrokeWidth="1dp"
+                app:boxStrokeWidthFocused="2dp"
+                app:boxBackgroundColor="@color/supabase_surface_alt">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/urlInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:autofillHints="username"
+                    android:textColor="@color/supabase_on_surface"
+                    android:textCursorDrawable="@null" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                android:id="@+id/engineLabel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textColor="@color/supabase_on_surface" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/connectButton"
+                style="@style/Widget.Material3.Button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="Проверить подключение"
+                android:textAllCaps="false"
+                android:textColor="@color/supabase_on_primary"
+                app:backgroundTint="@color/supabase_primary"
+                app:cornerRadius="12dp"
+                app:iconTint="@color/supabase_on_primary" />
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/tableInputLayout"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
                 android:hint="Имя таблицы"
                 android:textColorHint="@color/supabase_on_surface"
                 app:boxStrokeColor="@color/supabase_border"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,311 +9,327 @@
     android:padding="16dp"
     tools:context=".MainActivity">
 
-    <TextView
-        android:id="@+id/title"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="Supabase SQL Viewer"
-        android:textAppearance="@style/TextAppearance.Material3.HeadlineSmall"
-        android:textColor="@color/supabase_on_background"
+    <ScrollView
+        android:layout_width="374dp"
+        android:layout_height="672dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/controlsCard"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:padding="16dp"
-        app:cardBackgroundColor="@color/supabase_surface"
-        app:cardCornerRadius="16dp"
-        app:cardElevation="2dp"
-        app:strokeColor="@color/supabase_border"
-        app:strokeWidth="1dp"
-        app:layout_constraintTop_toBottomOf="@id/title"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-
-        <LinearLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
+
             <TextView
+                android:id="@+id/title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="URL подключения"
-                android:textColor="@color/supabase_on_surface"
-                android:textStyle="bold" />
+                android:layout_weight="1"
+                android:gravity="center"
+                android:text="Supabase SQL Viewer"
+                android:textAppearance="@style/TextAppearance.Material3.HeadlineSmall"
+                android:textColor="@color/supabase_on_background"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/urlInputLayout"
-                style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
-                android:layout_width="match_parent"
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/controlsCard"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:hint="Например, postgres://host:5432/db"
-                android:textColorHint="@color/supabase_on_surface"
-                app:boxStrokeColor="@color/supabase_border"
-                app:boxStrokeWidth="1dp"
-                app:boxStrokeWidthFocused="2dp"
-                app:boxBackgroundColor="@color/supabase_surface_alt">
+                android:layout_marginTop="16dp"
+                android:padding="16dp"
+                app:cardBackgroundColor="@color/supabase_surface"
+                app:cardCornerRadius="16dp"
+                app:cardElevation="2dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/title"
+                app:strokeColor="@color/supabase_border"
+                app:strokeWidth="1dp">
 
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/urlInput"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:autofillHints="username"
-                    android:textColor="@color/supabase_on_surface"
-                    android:textCursorDrawable="@null" />
-            </com.google.android.material.textfield.TextInputLayout>
+                    android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/engineLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:textColor="@color/supabase_on_surface" />
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="URL подключения"
+                        android:textColor="@color/supabase_on_surface"
+                        android:textStyle="bold" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/connectButton"
-                style="@style/Widget.Material3.Button"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                android:text="Проверить подключение"
-                android:textAllCaps="false"
-                android:textColor="@color/supabase_on_primary"
-                app:backgroundTint="@color/supabase_primary"
-                app:cornerRadius="12dp"
-                app:iconTint="@color/supabase_on_primary" />
-        </LinearLayout>
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/urlInputLayout"
+                        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="Например, postgres://host:5432/db"
+                        android:textColorHint="@color/supabase_on_surface"
+                        app:boxBackgroundColor="@color/supabase_surface_alt"
+                        app:boxStrokeColor="@color/supabase_border"
+                        app:boxStrokeWidth="1dp"
+                        app:boxStrokeWidthFocused="2dp">
 
-    </com.google.android.material.card.MaterialCardView>
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/urlInput"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:autofillHints="username"
+                            android:textColor="@color/supabase_on_surface"
+                            android:textCursorDrawable="@null" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/schemaCard"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:padding="16dp"
-        android:visibility="gone"
-        app:cardBackgroundColor="@color/supabase_surface"
-        app:cardCornerRadius="16dp"
-        app:cardElevation="2dp"
-        app:strokeColor="@color/supabase_border"
-        app:strokeWidth="1dp"
-        app:layout_constraintTop_toBottomOf="@id/controlsCard"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+                    <TextView
+                        android:id="@+id/engineLabel"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:textColor="@color/supabase_on_surface" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/connectButton"
+                        style="@style/Widget.Material3.Button"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:text="Проверить подключение"
+                        android:textAllCaps="false"
+                        android:textColor="@color/supabase_on_primary"
+                        app:backgroundTint="@color/supabase_primary"
+                        app:cornerRadius="12dp"
+                        app:iconTint="@color/supabase_on_primary" />
+                </LinearLayout>
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Схемы"
-                android:textColor="@color/supabase_on_surface"
-                android:textStyle="bold"
-                android:textSize="16sp" />
+            </com.google.android.material.card.MaterialCardView>
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:text="Нередактируемые схемы подсвечены"
-                android:textColor="@color/supabase_warning"
-                android:textSize="13sp" />
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/schemaRecycler"
-                android:layout_width="match_parent"
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/schemaCard"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="12dp"
-                tools:listitem="@layout/item_schema" />
-        </LinearLayout>
+                android:padding="16dp"
+                android:visibility="gone"
+                app:cardBackgroundColor="@color/supabase_surface"
+                app:cardCornerRadius="16dp"
+                app:cardElevation="2dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/controlsCard"
+                app:strokeColor="@color/supabase_border"
+                app:strokeWidth="1dp">
 
-    </com.google.android.material.card.MaterialCardView>
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/tableSelectorCard"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:padding="16dp"
-        android:visibility="gone"
-        app:cardBackgroundColor="@color/supabase_surface"
-        app:cardCornerRadius="16dp"
-        app:cardElevation="2dp"
-        app:strokeColor="@color/supabase_border"
-        app:strokeWidth="1dp"
-        app:layout_constraintTop_toBottomOf="@id/schemaCard"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Схемы"
+                        android:textColor="@color/supabase_on_surface"
+                        android:textSize="16sp"
+                        android:textStyle="bold" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:text="Нередактируемые схемы подсвечены"
+                        android:textColor="@color/supabase_warning"
+                        android:textSize="13sp" />
 
-            <TextView
-                android:id="@+id/selectedSchemaLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/supabase_on_surface"
-                android:textStyle="bold"
-                android:textSize="16sp" />
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/schemaRecycler"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        tools:listitem="@layout/item_schema" />
+                </LinearLayout>
 
-            <TextView
-                android:id="@+id/schemaAccessLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:textColor="@color/supabase_primary"
-                android:textSize="13sp" />
+            </com.google.android.material.card.MaterialCardView>
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/tableListRecycler"
-                android:layout_width="match_parent"
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/tableSelectorCard"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="12dp"
-                tools:listitem="@layout/item_table_entry" />
+                android:padding="16dp"
+                android:visibility="gone"
+                app:cardBackgroundColor="@color/supabase_surface"
+                app:cardCornerRadius="16dp"
+                app:cardElevation="2dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/schemaCard"
+                app:strokeColor="@color/supabase_border"
+                app:strokeWidth="1dp">
 
-            <TextView
-                android:id="@+id/selectedTableLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:textColor="@color/supabase_on_surface"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/limitLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                android:text="Лимит строк"
-                android:textColor="@color/supabase_on_surface" />
-
-            <com.google.android.material.button.MaterialButtonToggleGroup
-                android:id="@+id/limitToggleGroup"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:checkedButton="@id/limit100"
-                app:singleSelection="true">
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/limit100"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="100"
-                    android:textColor="@color/supabase_on_surface"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:rippleColor="@color/supabase_primary" />
+                    android:orientation="vertical">
 
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/limit1000"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="1000"
-                    android:textColor="@color/supabase_on_surface"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:rippleColor="@color/supabase_primary" />
+                    <TextView
+                        android:id="@+id/selectedSchemaLabel"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/supabase_on_surface"
+                        android:textSize="16sp"
+                        android:textStyle="bold" />
 
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/limit1500"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="1500"
-                    android:textColor="@color/supabase_on_surface"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:rippleColor="@color/supabase_primary" />
+                    <TextView
+                        android:id="@+id/schemaAccessLabel"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:textColor="@color/supabase_primary"
+                        android:textSize="13sp" />
 
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/limitNoLimit"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Без лимита"
-                    android:textColor="@color/supabase_on_surface"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:rippleColor="@color/supabase_primary" />
-            </com.google.android.material.button.MaterialButtonToggleGroup>
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/tableListRecycler"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        tools:listitem="@layout/item_table_entry" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                android:orientation="horizontal"
-                android:weightSum="2">
+                    <TextView
+                        android:id="@+id/selectedTableLabel"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:textColor="@color/supabase_on_surface"
+                        android:textSize="14sp" />
 
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/loadButton"
-                    style="@style/Widget.Material3.Button"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Открыть таблицу"
-                    android:textAllCaps="false"
-                    android:textColor="@color/supabase_on_primary"
-                    app:backgroundTint="@color/supabase_primary"
-                    app:cornerRadius="12dp"
-                    app:iconTint="@color/supabase_on_primary" />
+                    <TextView
+                        android:id="@+id/limitLabel"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:text="Лимит строк"
+                        android:textColor="@color/supabase_on_surface" />
 
-                <Space
-                    android:layout_width="12dp"
-                    android:layout_height="wrap_content" />
+                    <com.google.android.material.button.MaterialButtonToggleGroup
+                        android:id="@+id/limitToggleGroup"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:checkedButton="@id/limit100"
+                        app:singleSelection="true">
 
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/addTableButton"
-                    style="@style/Widget.Material3.Button"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Добавить таблицу"
-                    android:textAllCaps="false"
-                    android:textColor="@color/supabase_on_primary"
-                    app:backgroundTint="@color/supabase_primary_dark"
-                    app:cornerRadius="12dp"
-                    app:iconTint="@color/supabase_on_primary" />
-            </LinearLayout>
-        </LinearLayout>
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/limit100"
+                            style="@style/Widget.Material3.Button.OutlinedButton"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="100"
+                            android:textColor="@color/supabase_on_surface"
+                            app:backgroundTint="@color/supabase_surface_high"
+                            app:rippleColor="@color/supabase_primary" />
 
-    </com.google.android.material.card.MaterialCardView>
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/limit1000"
+                            style="@style/Widget.Material3.Button.OutlinedButton"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="1000"
+                            android:textColor="@color/supabase_on_surface"
+                            app:backgroundTint="@color/supabase_surface_high"
+                            app:rippleColor="@color/supabase_primary" />
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/tableCard"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="16dp"
-        app:cardBackgroundColor="@color/supabase_surface_high"
-        app:cardCornerRadius="16dp"
-        app:cardElevation="0dp"
-        app:strokeColor="@color/supabase_border"
-        app:strokeWidth="1dp"
-        app:layout_constraintTop_toBottomOf="@id/tableSelectorCard"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/limit1500"
+                            style="@style/Widget.Material3.Button.OutlinedButton"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="1500"
+                            android:textColor="@color/supabase_on_surface"
+                            app:backgroundTint="@color/supabase_surface_high"
+                            app:rippleColor="@color/supabase_primary" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/tableRecycler"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:padding="12dp"
-            tools:listitem="@layout/item_table_row" />
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/limitNoLimit"
+                            style="@style/Widget.Material3.Button.OutlinedButton"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="Без лимита"
+                            android:textColor="@color/supabase_on_surface"
+                            app:backgroundTint="@color/supabase_surface_high"
+                            app:rippleColor="@color/supabase_primary" />
+                    </com.google.android.material.button.MaterialButtonToggleGroup>
 
-    </com.google.android.material.card.MaterialCardView>
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:orientation="horizontal"
+                        android:weightSum="2">
 
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/loadButton"
+                            style="@style/Widget.Material3.Button"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="Открыть таблицу"
+                            android:textAllCaps="false"
+                            android:textColor="@color/supabase_on_primary"
+                            app:backgroundTint="@color/supabase_primary"
+                            app:cornerRadius="12dp"
+                            app:iconTint="@color/supabase_on_primary" />
+
+                        <Space
+                            android:layout_width="12dp"
+                            android:layout_height="wrap_content" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/addTableButton"
+                            style="@style/Widget.Material3.Button"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="Добавить таблицу"
+                            android:textAllCaps="false"
+                            android:textColor="@color/supabase_on_primary"
+                            app:backgroundTint="@color/supabase_primary_dark"
+                            app:cornerRadius="12dp"
+                            app:iconTint="@color/supabase_on_primary" />
+                    </LinearLayout>
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/tableCard"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="16dp"
+                app:cardBackgroundColor="@color/supabase_surface_high"
+                app:cardCornerRadius="16dp"
+                app:cardElevation="0dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tableSelectorCard"
+                app:strokeColor="@color/supabase_border"
+                app:strokeWidth="1dp">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/tableRecycler"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:padding="12dp"
+                    tools:listitem="@layout/item_table_row" />
+
+            </com.google.android.material.card.MaterialCardView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -88,28 +88,108 @@
                 app:backgroundTint="@color/supabase_primary"
                 app:cornerRadius="12dp"
                 app:iconTint="@color/supabase_on_primary" />
+        </LinearLayout>
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/tableInputLayout"
-                style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/schemaCard"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:padding="16dp"
+        android:visibility="gone"
+        app:cardBackgroundColor="@color/supabase_surface"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="2dp"
+        app:strokeColor="@color/supabase_border"
+        app:strokeWidth="1dp"
+        app:layout_constraintTop_toBottomOf="@id/controlsCard"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Схемы"
+                android:textColor="@color/supabase_on_surface"
+                android:textStyle="bold"
+                android:textSize="16sp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="Нередактируемые схемы подсвечены"
+                android:textColor="@color/supabase_warning"
+                android:textSize="13sp" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/schemaRecycler"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="12dp"
-                android:hint="Имя таблицы"
-                android:textColorHint="@color/supabase_on_surface"
-                app:boxStrokeColor="@color/supabase_border"
-                app:boxStrokeWidth="1dp"
-                app:boxStrokeWidthFocused="2dp"
-                app:boxBackgroundColor="@color/supabase_surface_alt">
+                tools:listitem="@layout/item_schema" />
+        </LinearLayout>
 
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/tableNameInput"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="demo_users"
-                    android:textColor="@color/supabase_on_surface"
-                    android:textCursorDrawable="@null" />
-            </com.google.android.material.textfield.TextInputLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/tableSelectorCard"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:padding="16dp"
+        android:visibility="gone"
+        app:cardBackgroundColor="@color/supabase_surface"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="2dp"
+        app:strokeColor="@color/supabase_border"
+        app:strokeWidth="1dp"
+        app:layout_constraintTop_toBottomOf="@id/schemaCard"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/selectedSchemaLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/supabase_on_surface"
+                android:textStyle="bold"
+                android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/schemaAccessLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textColor="@color/supabase_primary"
+                android:textSize="13sp" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/tableListRecycler"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                tools:listitem="@layout/item_table_entry" />
+
+            <TextView
+                android:id="@+id/selectedTableLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textColor="@color/supabase_on_surface"
+                android:textSize="14sp" />
 
             <TextView
                 android:id="@+id/limitLabel"
@@ -171,18 +251,43 @@
                     app:rippleColor="@color/supabase_primary" />
             </com.google.android.material.button.MaterialButtonToggleGroup>
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/loadButton"
-                style="@style/Widget.Material3.Button"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="12dp"
-                android:text="Показать данные"
-                android:textAllCaps="false"
-                android:textColor="@color/supabase_on_primary"
-                app:backgroundTint="@color/supabase_primary"
-                app:cornerRadius="12dp"
-                app:iconTint="@color/supabase_on_primary" />
+                android:orientation="horizontal"
+                android:weightSum="2">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/loadButton"
+                    style="@style/Widget.Material3.Button"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Открыть таблицу"
+                    android:textAllCaps="false"
+                    android:textColor="@color/supabase_on_primary"
+                    app:backgroundTint="@color/supabase_primary"
+                    app:cornerRadius="12dp"
+                    app:iconTint="@color/supabase_on_primary" />
+
+                <Space
+                    android:layout_width="12dp"
+                    android:layout_height="wrap_content" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/addTableButton"
+                    style="@style/Widget.Material3.Button"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Добавить таблицу"
+                    android:textAllCaps="false"
+                    android:textColor="@color/supabase_on_primary"
+                    app:backgroundTint="@color/supabase_primary_dark"
+                    app:cornerRadius="12dp"
+                    app:iconTint="@color/supabase_on_primary" />
+            </LinearLayout>
         </LinearLayout>
 
     </com.google.android.material.card.MaterialCardView>
@@ -197,7 +302,7 @@
         app:cardElevation="0dp"
         app:strokeColor="@color/supabase_border"
         app:strokeWidth="1dp"
-        app:layout_constraintTop_toBottomOf="@id/controlsCard"
+        app:layout_constraintTop_toBottomOf="@id/tableSelectorCard"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">

--- a/app/src/main/res/layout/item_schema.xml
+++ b/app/src/main/res/layout/item_schema.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
+    android:foreground="?attr/selectableItemBackground"
+    app:cardElevation="2dp"
+    app:cardCornerRadius="12dp"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/schemaName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/supabase_on_surface"
+            android:textStyle="bold"
+            android:textSize="16sp" />
+
+        <TextView
+            android:id="@+id/schemaMode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textColor="@color/supabase_primary"
+            android:textSize="13sp" />
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_table_entry.xml
+++ b/app/src/main/res/layout/item_table_entry.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/tableItemContainer"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/tableItemName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/supabase_on_surface"
+        android:textSize="15sp"
+        android:textStyle="bold" />
+
+</LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,6 +11,7 @@
     <color name="supabase_on_background">#E5E7EB</color>
     <color name="supabase_on_surface">#D1D5DB</color>
     <color name="supabase_on_primary">#0A0F1F</color>
+    <color name="supabase_warning">#F59E0B</color>
 
     <color name="black" tools:ignore="UnusedResources">#FF000000</color>
     <color name="white" tools:ignore="UnusedResources">#FFFFFFFF</color>


### PR DESCRIPTION
## Summary
- add first connection block with URL input, engine hint, and connect action
- implement URL engine resolver to detect database type from scheme
- restrict table loading until a valid connection is established

## Testing
- not run (Android tooling not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693b39580c60832fa783e8f5b52ebdf7)