### PR TITLE
Split schema selection into its own screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".SchemaSelectionActivity"
+            android:exported="false" />
+        <activity
+            android:name=".TableSelectionActivity"
+            android:exported="false" />
+        <activity
+            android:name=".TableDataActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/amnesiawho/sqlviewer/MainActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/MainActivity.java
@@ -1,12 +1,10 @@
 package com.amnesiawho.sqlviewer;
 
+import android.content.Intent;
 import android.os.Bundle;
-import android.view.View;
-import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
-import android.widget.Spinner;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.activity.EdgeToEdge;
@@ -14,26 +12,17 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 
-import com.amnesiawho.sqlviewer.core.exception.GlobalExceptionHandler;
 import com.amnesiawho.sqlviewer.data.db.DatabaseManager;
 import com.amnesiawho.sqlviewer.data.db.DbEngineType;
-import com.amnesiawho.sqlviewer.data.db.TableData;
-import com.amnesiawho.sqlviewer.ui.table.TableAdapter;
-import com.google.android.material.button.MaterialButtonToggleGroup;
-
-import java.util.ArrayList;
-import java.util.List;
+import com.amnesiawho.sqlviewer.data.db.UrlEngineResolver;
 
 public class MainActivity extends AppCompatActivity {
 
     private DatabaseManager databaseManager;
-    private TableAdapter tableAdapter;
-    private MaterialButtonToggleGroup limitToggleGroup;
-    private EditText tableNameInput;
-    private Spinner engineSpinner;
+    private EditText urlInput;
+    private TextView engineLabel;
+    private Button connectButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -49,88 +38,50 @@ public class MainActivity extends AppCompatActivity {
         // Инициализация инфраструктуры
         databaseManager = new DatabaseManager(this);
         setupViews();
-        setupEngineSpinner();
-        setupLimitSelector();
-
-        // Загружаем данные сразу, чтобы пользователь видел демо-таблицу
-        loadTable();
+        setupConnectionBlock();
     }
 
     private void setupViews() {
-        tableNameInput = findViewById(R.id.tableNameInput);
-        engineSpinner = findViewById(R.id.engineSpinner);
-        limitToggleGroup = findViewById(R.id.limitToggleGroup);
-        RecyclerView tableRecycler = findViewById(R.id.tableRecycler);
-        Button loadButton = findViewById(R.id.loadButton);
-
-        tableAdapter = new TableAdapter(this);
-        tableRecycler.setLayoutManager(new LinearLayoutManager(this));
-        tableRecycler.setAdapter(tableAdapter);
-
-        // Кнопка загрузки данных
-        loadButton.setOnClickListener(v -> loadTable());
+        urlInput = findViewById(R.id.urlInput);
+        engineLabel = findViewById(R.id.engineLabel);
+        connectButton = findViewById(R.id.connectButton);
     }
 
-    private void setupEngineSpinner() {
-        // Собираем список заголовков и связываем с перечислением
-        List<String> titles = new ArrayList<>();
-        for (DbEngineType type : DbEngineType.values()) {
-            titles.add(type.getTitle());
+    private void setupConnectionBlock() {
+        connectButton.setOnClickListener(v -> attemptConnection());
+        urlInput.setText("sqlite://demo");
+        updateEngineLabel(null);
+    }
+
+    private void attemptConnection() {
+        String url = urlInput.getText().toString().trim();
+        if (url.isEmpty()) {
+            Toast.makeText(this, "Введите URL подключения", Toast.LENGTH_SHORT).show();
+            return;
         }
-        ArrayAdapter<String> adapter = new ArrayAdapter<>(this, R.layout.item_spinner_dark, titles);
-        adapter.setDropDownViewResource(R.layout.item_spinner_dark);
-        engineSpinner.setAdapter(adapter);
-        engineSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                DbEngineType selected = DbEngineType.values()[position];
-                databaseManager.switchEngine(selected);
-                loadTable();
-            }
-
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-                // Ничего не делаем
-            }
-        });
-    }
-
-    private void setupLimitSelector() {
-        // Устанавливаем обработчик смены лимита
-        limitToggleGroup.addOnButtonCheckedListener((group, checkedId, isChecked) -> {
-            if (isChecked) {
-                loadTable();
-            }
-        });
-    }
-
-    private int getSelectedLimit() {
-        int checkedId = limitToggleGroup.getCheckedButtonId();
-        if (checkedId == R.id.limit100) {
-            return 100;
-        } else if (checkedId == R.id.limit1000) {
-            return 1000;
-        } else if (checkedId == R.id.limit1500) {
-            return 1500;
-        } else if (checkedId == R.id.limitNoLimit) {
-            return -1;
-        }
-        // Значение по умолчанию
-        return 100;
-    }
-
-    private void loadTable() {
-        String tableName = tableNameInput.getText().toString();
-        int limit = getSelectedLimit();
         try {
-            TableData data = databaseManager.readTable(tableName, limit);
-            tableAdapter.setData(data);
-            if (data.isEmpty()) {
-                Toast.makeText(this, "Данных нет или таблица пуста", Toast.LENGTH_SHORT).show();
-            }
-        } catch (Exception e) {
-            // Пробрасываем ошибку в общий обработчик
-            GlobalExceptionHandler.reportHandled(this, e);
+            DbEngineType engineType = UrlEngineResolver.resolve(url);
+            databaseManager.switchEngine(engineType);
+            updateEngineLabel(engineType);
+            Toast.makeText(this, "Подключение успешно: " + engineType.getTitle(), Toast.LENGTH_SHORT).show();
+            openSchemaSelection(engineType);
+        } catch (IllegalArgumentException ex) {
+            updateEngineLabel(null);
+            Toast.makeText(this, ex.getMessage(), Toast.LENGTH_LONG).show();
         }
+    }
+
+    private void updateEngineLabel(DbEngineType engineType) {
+        if (engineType == null) {
+            engineLabel.setText("Движок будет определён автоматически");
+        } else {
+            engineLabel.setText("Определён движок: " + engineType.getTitle());
+        }
+    }
+
+    private void openSchemaSelection(DbEngineType engineType) {
+        Intent intent = new Intent(this, SchemaSelectionActivity.class);
+        intent.putExtra(SchemaSelectionActivity.EXTRA_ENGINE_TYPE, engineType.name());
+        startActivity(intent);
     }
 }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/MainActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/MainActivity.java
@@ -23,6 +23,7 @@ public class MainActivity extends AppCompatActivity {
     private EditText urlInput;
     private TextView engineLabel;
     private Button connectButton;
+    private String lastConnectionUrl;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -61,11 +62,18 @@ public class MainActivity extends AppCompatActivity {
         }
         try {
             DbEngineType engineType = UrlEngineResolver.resolve(url);
-            databaseManager.switchEngine(engineType);
+            databaseManager.switchEngine(engineType, url);
             updateEngineLabel(engineType);
             Toast.makeText(this, "Подключение успешно: " + engineType.getTitle(), Toast.LENGTH_SHORT).show();
-            openSchemaSelection(engineType);
+            lastConnectionUrl = url;
+            openSchemaSelection(engineType, url);
         } catch (IllegalArgumentException ex) {
+            updateEngineLabel(null);
+            Toast.makeText(this, ex.getMessage(), Toast.LENGTH_LONG).show();
+        } catch (UnsupportedOperationException ex) {
+            updateEngineLabel(null);
+            Toast.makeText(this, ex.getMessage(), Toast.LENGTH_LONG).show();
+        } catch (IllegalStateException ex) {
             updateEngineLabel(null);
             Toast.makeText(this, ex.getMessage(), Toast.LENGTH_LONG).show();
         }
@@ -79,9 +87,10 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    private void openSchemaSelection(DbEngineType engineType) {
+    private void openSchemaSelection(DbEngineType engineType, String connectionUrl) {
         Intent intent = new Intent(this, SchemaSelectionActivity.class);
         intent.putExtra(SchemaSelectionActivity.EXTRA_ENGINE_TYPE, engineType.name());
+        intent.putExtra(SchemaSelectionActivity.EXTRA_CONNECTION_URL, connectionUrl);
         startActivity(intent);
     }
 }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/SchemaSelectionActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/SchemaSelectionActivity.java
@@ -1,0 +1,91 @@
+package com.amnesiawho.sqlviewer;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.activity.EdgeToEdge;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.amnesiawho.sqlviewer.core.exception.GlobalExceptionHandler;
+import com.amnesiawho.sqlviewer.data.db.DatabaseManager;
+import com.amnesiawho.sqlviewer.data.db.DbEngineType;
+import com.amnesiawho.sqlviewer.data.db.SchemaInfo;
+import com.amnesiawho.sqlviewer.ui.schema.SchemaAdapter;
+
+import java.util.List;
+
+public class SchemaSelectionActivity extends AppCompatActivity {
+
+    public static final String EXTRA_ENGINE_TYPE = "engine_type";
+
+    private DatabaseManager databaseManager;
+    private SchemaAdapter schemaAdapter;
+    private TextView engineTitleLabel;
+    private DbEngineType engineType;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
+        setContentView(R.layout.activity_schema_selection);
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.schemaSelectionRoot), (v, insets) -> {
+            Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+            return insets;
+        });
+
+        String engineTypeName = getIntent().getStringExtra(EXTRA_ENGINE_TYPE);
+        if (engineTypeName == null) {
+            Toast.makeText(this, "Не удалось определить подключение", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+
+        engineType = DbEngineType.valueOf(engineTypeName);
+        databaseManager = new DatabaseManager(this);
+        databaseManager.switchEngine(engineType);
+
+        setupViews();
+        loadSchemas();
+    }
+
+    private void setupViews() {
+        engineTitleLabel = findViewById(R.id.schemaEngineLabel);
+        engineTitleLabel.setText("Движок: " + engineType.getTitle());
+
+        RecyclerView schemaRecycler = findViewById(R.id.schemaSelectionRecycler);
+        schemaAdapter = new SchemaAdapter(this::onSchemaSelected);
+        schemaRecycler.setLayoutManager(new LinearLayoutManager(this));
+        schemaRecycler.setAdapter(schemaAdapter);
+    }
+
+    private void loadSchemas() {
+        try {
+            List<SchemaInfo> schemas = databaseManager.listSchemas();
+            schemaAdapter.setItems(schemas);
+            schemaAdapter.setSelectedSchema(null);
+            findViewById(R.id.schemaSelectionCard).setVisibility(View.VISIBLE);
+        } catch (Exception e) {
+            findViewById(R.id.schemaSelectionCard).setVisibility(View.GONE);
+            GlobalExceptionHandler.reportHandled(this, e);
+            Toast.makeText(this, "Не удалось загрузить схемы", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void onSchemaSelected(SchemaInfo schemaInfo) {
+        schemaAdapter.setSelectedSchema(schemaInfo.getName());
+        Intent intent = new Intent(this, TableSelectionActivity.class);
+        intent.putExtra(TableSelectionActivity.EXTRA_SCHEMA_NAME, schemaInfo.getName());
+        intent.putExtra(TableSelectionActivity.EXTRA_SCHEMA_EDITABLE, schemaInfo.isEditable());
+        intent.putExtra(TableSelectionActivity.EXTRA_ENGINE_TYPE, engineType.name());
+        startActivity(intent);
+    }
+}

--- a/app/src/main/java/com/amnesiawho/sqlviewer/SchemaSelectionActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/SchemaSelectionActivity.java
@@ -25,11 +25,13 @@ import java.util.List;
 public class SchemaSelectionActivity extends AppCompatActivity {
 
     public static final String EXTRA_ENGINE_TYPE = "engine_type";
+    public static final String EXTRA_CONNECTION_URL = "connection_url";
 
     private DatabaseManager databaseManager;
     private SchemaAdapter schemaAdapter;
     private TextView engineTitleLabel;
     private DbEngineType engineType;
+    private String connectionUrl;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -43,6 +45,7 @@ public class SchemaSelectionActivity extends AppCompatActivity {
         });
 
         String engineTypeName = getIntent().getStringExtra(EXTRA_ENGINE_TYPE);
+        connectionUrl = getIntent().getStringExtra(EXTRA_CONNECTION_URL);
         if (engineTypeName == null) {
             Toast.makeText(this, "Не удалось определить подключение", Toast.LENGTH_SHORT).show();
             finish();
@@ -51,7 +54,13 @@ public class SchemaSelectionActivity extends AppCompatActivity {
 
         engineType = DbEngineType.valueOf(engineTypeName);
         databaseManager = new DatabaseManager(this);
-        databaseManager.switchEngine(engineType);
+        try {
+            databaseManager.switchEngine(engineType, connectionUrl);
+        } catch (Exception e) {
+            Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
+            finish();
+            return;
+        }
 
         setupViews();
         loadSchemas();
@@ -86,6 +95,7 @@ public class SchemaSelectionActivity extends AppCompatActivity {
         intent.putExtra(TableSelectionActivity.EXTRA_SCHEMA_NAME, schemaInfo.getName());
         intent.putExtra(TableSelectionActivity.EXTRA_SCHEMA_EDITABLE, schemaInfo.isEditable());
         intent.putExtra(TableSelectionActivity.EXTRA_ENGINE_TYPE, engineType.name());
+        intent.putExtra(TableSelectionActivity.EXTRA_CONNECTION_URL, connectionUrl);
         startActivity(intent);
     }
 }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/TableDataActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/TableDataActivity.java
@@ -1,7 +1,10 @@
 package com.amnesiawho.sqlviewer;
 
 import android.os.Bundle;
+import android.content.ContentValues;
+import android.view.View;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -19,6 +22,9 @@ import com.amnesiawho.sqlviewer.data.db.DbEngineType;
 import com.amnesiawho.sqlviewer.data.db.TableData;
 import com.amnesiawho.sqlviewer.ui.table.TableAdapter;
 import com.google.android.material.button.MaterialButtonToggleGroup;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 
 public class TableDataActivity extends AppCompatActivity {
 
@@ -28,10 +34,18 @@ public class TableDataActivity extends AppCompatActivity {
     private TextView tableTitle;
     private TextView schemaLabel;
     private TextView editabilityLabel;
+    private TextView selectedRowLabel;
+    private Button addRowButton;
+    private Button editRowButton;
+    private Button deleteRowButton;
+    private View crudButtonsRow;
 
     private String schemaName;
     private String tableName;
     private boolean schemaEditable;
+    private TableData currentData;
+    private int selectedRowIndex = -1;
+    private java.util.List<String> selectedRowData;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -74,13 +88,18 @@ public class TableDataActivity extends AppCompatActivity {
         tableTitle = findViewById(R.id.tableNameTitle);
         schemaLabel = findViewById(R.id.dataSchemaLabel);
         editabilityLabel = findViewById(R.id.dataSchemaAccessLabel);
+        selectedRowLabel = findViewById(R.id.selectedRowLabel);
+        crudButtonsRow = findViewById(R.id.crudButtonsRow);
+        addRowButton = findViewById(R.id.addRowButton);
+        editRowButton = findViewById(R.id.editRowButton);
+        deleteRowButton = findViewById(R.id.deleteRowButton);
         limitToggleGroup = findViewById(R.id.dataLimitToggleGroup);
         Button reloadButton = findViewById(R.id.reloadTableButton);
         Button rlsButton = findViewById(R.id.rlsButton);
 
         RecyclerView recyclerView = findViewById(R.id.dataRecycler);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
-        tableAdapter = new TableAdapter(this);
+        tableAdapter = new TableAdapter(this, this::onRowSelected);
         recyclerView.setAdapter(tableAdapter);
 
         limitToggleGroup.addOnButtonCheckedListener((group, checkedId, isChecked) -> {
@@ -91,6 +110,11 @@ public class TableDataActivity extends AppCompatActivity {
 
         reloadButton.setOnClickListener(v -> loadTable());
         rlsButton.setOnClickListener(v -> Toast.makeText(this, "Политики RLS скоро будут доступны", Toast.LENGTH_SHORT).show());
+
+        addRowButton.setOnClickListener(v -> showRowDialog(false));
+        editRowButton.setOnClickListener(v -> showRowDialog(true));
+        deleteRowButton.setOnClickListener(v -> confirmDelete());
+        applyCrudVisibility();
     }
 
     private void bindHeader() {
@@ -115,14 +139,174 @@ public class TableDataActivity extends AppCompatActivity {
     private void loadTable() {
         int limit = resolveLimit();
         try {
-            TableData data = databaseManager.readTable(schemaName, tableName, limit);
-            tableAdapter.setData(data);
-            if (data.isEmpty()) {
+            currentData = databaseManager.readTable(schemaName, tableName, limit);
+            tableAdapter.setData(currentData);
+            clearSelection();
+            if (currentData.isEmpty()) {
                 Toast.makeText(this, "Данных нет или таблица пуста", Toast.LENGTH_SHORT).show();
             }
         } catch (Exception e) {
             GlobalExceptionHandler.reportHandled(this, e);
             Toast.makeText(this, "Не удалось загрузить данные таблицы", Toast.LENGTH_SHORT).show();
         }
+    }
+
+    private void applyCrudVisibility() {
+        crudButtonsRow.setVisibility(schemaEditable ? View.VISIBLE : View.GONE);
+        addRowButton.setEnabled(schemaEditable);
+        editRowButton.setEnabled(false);
+        deleteRowButton.setEnabled(false);
+    }
+
+    private void onRowSelected(int rowIndex, java.util.List<String> rowData) {
+        selectedRowIndex = rowIndex;
+        selectedRowData = new java.util.ArrayList<>(rowData);
+        selectedRowLabel.setText("Выбрана строка #" + (rowIndex + 1));
+        tableAdapter.setSelectedRowIndex(rowIndex);
+        editRowButton.setEnabled(schemaEditable);
+        deleteRowButton.setEnabled(schemaEditable);
+    }
+
+    private void clearSelection() {
+        selectedRowIndex = -1;
+        selectedRowData = null;
+        selectedRowLabel.setText("Строка не выбрана");
+        tableAdapter.setSelectedRowIndex(-1);
+        editRowButton.setEnabled(false);
+        deleteRowButton.setEnabled(false);
+    }
+
+    private void showRowDialog(boolean isEdit) {
+        if (!schemaEditable) {
+            Toast.makeText(this, "Редактирование недоступно", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        if (currentData == null || currentData.getColumns().isEmpty()) {
+            Toast.makeText(this, "Нет данных для редактирования", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        int idIndex = findIdColumnIndex();
+        if (isEdit && (selectedRowIndex < 0 || selectedRowData == null)) {
+            Toast.makeText(this, "Выберите строку для изменения", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        if (isEdit && idIndex < 0) {
+            Toast.makeText(this, "Редактирование невозможно: отсутствует столбец id", Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        LinearLayout container = new LinearLayout(this);
+        container.setOrientation(LinearLayout.VERTICAL);
+        int padding = (int) (16 * getResources().getDisplayMetrics().density);
+        container.setPadding(padding, padding / 2, padding, 0);
+
+        java.util.List<TextInputEditText> inputs = new java.util.ArrayList<>();
+        for (int i = 0; i < currentData.getColumns().size(); i++) {
+            String column = currentData.getColumns().get(i);
+            if ("id".equalsIgnoreCase(column)) {
+                continue;
+            }
+            TextInputLayout layout = new TextInputLayout(this, null, com.google.android.material.R.style.Widget_Material3_TextInputLayout_OutlinedBox);
+            layout.setHint(column);
+            TextInputEditText editText = new TextInputEditText(layout.getContext());
+            layout.addView(editText);
+            if (isEdit && selectedRowData != null && i < selectedRowData.size()) {
+                editText.setText(selectedRowData.get(i));
+            }
+            inputs.add(editText);
+            container.addView(layout);
+        }
+
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(isEdit ? "Изменить строку" : "Добавить строку")
+                .setView(container)
+                .setNegativeButton("Отмена", (dialog, which) -> dialog.dismiss())
+                .setPositiveButton(isEdit ? "Сохранить" : "Добавить", (dialog, which) -> {
+                    ContentValues values = new ContentValues();
+                    int inputIndex = 0;
+                    for (String column : currentData.getColumns()) {
+                        if ("id".equalsIgnoreCase(column)) {
+                            continue;
+                        }
+                        String value = inputs.get(inputIndex).getText() != null ? inputs.get(inputIndex).getText().toString() : "";
+                        values.put(column, value);
+                        inputIndex++;
+                    }
+                    if (isEdit) {
+                        updateRow(idIndex, values);
+                    } else {
+                        addRow(values);
+                    }
+                })
+                .show();
+    }
+
+    private void addRow(ContentValues values) {
+        try {
+            databaseManager.insert(schemaName, tableName, values);
+            Toast.makeText(this, "Строка добавлена", Toast.LENGTH_SHORT).show();
+            loadTable();
+        } catch (Exception e) {
+            GlobalExceptionHandler.reportHandled(this, e);
+            Toast.makeText(this, "Не удалось добавить строку", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void updateRow(int idIndex, ContentValues values) {
+        if (selectedRowData == null || idIndex >= selectedRowData.size()) {
+            Toast.makeText(this, "Невозможно обновить строку", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        String idValue = selectedRowData.get(idIndex);
+        try {
+            databaseManager.update(schemaName, tableName, values, "id = ?", new String[]{idValue});
+            Toast.makeText(this, "Строка обновлена", Toast.LENGTH_SHORT).show();
+            loadTable();
+        } catch (Exception e) {
+            GlobalExceptionHandler.reportHandled(this, e);
+            Toast.makeText(this, "Не удалось обновить строку", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void confirmDelete() {
+        int idIndex = findIdColumnIndex();
+        if (selectedRowData == null || selectedRowIndex < 0) {
+            Toast.makeText(this, "Выберите строку для удаления", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        if (idIndex < 0) {
+            Toast.makeText(this, "Удаление невозможно: отсутствует столбец id", Toast.LENGTH_LONG).show();
+            return;
+        }
+        String idValue = selectedRowData.get(idIndex);
+        new MaterialAlertDialogBuilder(this)
+                .setTitle("Удалить строку?")
+                .setMessage("Это действие необратимо.")
+                .setNegativeButton("Отмена", (dialog, which) -> dialog.dismiss())
+                .setPositiveButton("Удалить", (dialog, which) -> deleteRow(idValue))
+                .show();
+    }
+
+    private void deleteRow(String idValue) {
+        try {
+            databaseManager.delete(schemaName, tableName, "id = ?", new String[]{idValue});
+            Toast.makeText(this, "Строка удалена", Toast.LENGTH_SHORT).show();
+            loadTable();
+        } catch (Exception e) {
+            GlobalExceptionHandler.reportHandled(this, e);
+            Toast.makeText(this, "Не удалось удалить строку", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private int findIdColumnIndex() {
+        if (currentData == null || currentData.getColumns().isEmpty()) {
+            return -1;
+        }
+        for (int i = 0; i < currentData.getColumns().size(); i++) {
+            if ("id".equalsIgnoreCase(currentData.getColumns().get(i))) {
+                return i;
+            }
+        }
+        return -1;
     }
 }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/TableDataActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/TableDataActivity.java
@@ -140,11 +140,11 @@ public class TableDataActivity extends AppCompatActivity {
         int limit = resolveLimit();
         try {
             currentData = databaseManager.readTable(schemaName, tableName, limit);
-        tableAdapter.setData(currentData);
-        clearSelection();
-        if (currentData.isEmpty()) {
-            Toast.makeText(this, "Данных нет или таблица пуста", Toast.LENGTH_SHORT).show();
-        }
+            tableAdapter.setData(currentData);
+            clearSelection();
+            if (currentData.isEmpty()) {
+                Toast.makeText(this, "Данных нет или таблица пуста", Toast.LENGTH_SHORT).show();
+            }
         } catch (Exception e) {
             GlobalExceptionHandler.reportHandled(this, e);
             Toast.makeText(this, "Не удалось загрузить данные таблицы", Toast.LENGTH_SHORT).show();
@@ -158,7 +158,7 @@ public class TableDataActivity extends AppCompatActivity {
         deleteRowButton.setEnabled(false);
     }
 
-    private void onRowSelected(int rowIndex, java.util.List<String> rowData) {
+    private void onRowSelected(int rowIndex, boolean isSelected) {
         if (isSelected) {
             selectedRows.add(rowIndex);
         } else {

--- a/app/src/main/java/com/amnesiawho/sqlviewer/TableDataActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/TableDataActivity.java
@@ -48,6 +48,7 @@ public class TableDataActivity extends AppCompatActivity {
         schemaEditable = getIntent().getBooleanExtra(TableSelectionActivity.EXTRA_SCHEMA_EDITABLE, false);
         tableName = getIntent().getStringExtra(TableSelectionActivity.EXTRA_SELECTED_TABLE);
         String engineTypeName = getIntent().getStringExtra(TableSelectionActivity.EXTRA_ENGINE_TYPE);
+        String connectionUrl = getIntent().getStringExtra(TableSelectionActivity.EXTRA_CONNECTION_URL);
 
         if (schemaName == null || tableName == null || engineTypeName == null) {
             Toast.makeText(this, "Не удалось открыть данные таблицы", Toast.LENGTH_SHORT).show();
@@ -56,7 +57,13 @@ public class TableDataActivity extends AppCompatActivity {
         }
 
         databaseManager = new DatabaseManager(this);
-        databaseManager.switchEngine(DbEngineType.valueOf(engineTypeName));
+        try {
+            databaseManager.switchEngine(DbEngineType.valueOf(engineTypeName), connectionUrl);
+        } catch (Exception e) {
+            Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
+            finish();
+            return;
+        }
 
         setupViews();
         bindHeader();

--- a/app/src/main/java/com/amnesiawho/sqlviewer/TableDataActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/TableDataActivity.java
@@ -45,7 +45,7 @@ public class TableDataActivity extends AppCompatActivity {
     private boolean schemaEditable;
     private TableData currentData;
     private int selectedRowIndex = -1;
-    private java.util.List<String> selectedRowData;
+    private final java.util.Set<Integer> selectedRows = new java.util.HashSet<>();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -140,11 +140,11 @@ public class TableDataActivity extends AppCompatActivity {
         int limit = resolveLimit();
         try {
             currentData = databaseManager.readTable(schemaName, tableName, limit);
-            tableAdapter.setData(currentData);
-            clearSelection();
-            if (currentData.isEmpty()) {
-                Toast.makeText(this, "Данных нет или таблица пуста", Toast.LENGTH_SHORT).show();
-            }
+        tableAdapter.setData(currentData);
+        clearSelection();
+        if (currentData.isEmpty()) {
+            Toast.makeText(this, "Данных нет или таблица пуста", Toast.LENGTH_SHORT).show();
+        }
         } catch (Exception e) {
             GlobalExceptionHandler.reportHandled(this, e);
             Toast.makeText(this, "Не удалось загрузить данные таблицы", Toast.LENGTH_SHORT).show();
@@ -159,21 +159,31 @@ public class TableDataActivity extends AppCompatActivity {
     }
 
     private void onRowSelected(int rowIndex, java.util.List<String> rowData) {
-        selectedRowIndex = rowIndex;
-        selectedRowData = new java.util.ArrayList<>(rowData);
-        selectedRowLabel.setText("Выбрана строка #" + (rowIndex + 1));
-        tableAdapter.setSelectedRowIndex(rowIndex);
-        editRowButton.setEnabled(schemaEditable);
-        deleteRowButton.setEnabled(schemaEditable);
+        if (isSelected) {
+            selectedRows.add(rowIndex);
+        } else {
+            selectedRows.remove(rowIndex);
+        }
+        updateSelectionState();
     }
 
     private void clearSelection() {
-        selectedRowIndex = -1;
-        selectedRowData = null;
-        selectedRowLabel.setText("Строка не выбрана");
-        tableAdapter.setSelectedRowIndex(-1);
-        editRowButton.setEnabled(false);
-        deleteRowButton.setEnabled(false);
+        selectedRows.clear();
+        updateSelectionState();
+    }
+
+    private void updateSelectionState() {
+        if (selectedRows.isEmpty()) {
+            selectedRowLabel.setText("Строки не выбраны");
+        } else if (selectedRows.size() == 1) {
+            int idx = selectedRows.iterator().next();
+            selectedRowLabel.setText("Выбрана строка #" + (idx + 1));
+        } else {
+            selectedRowLabel.setText("Выбрано строк: " + selectedRows.size());
+        }
+        tableAdapter.setSelection(selectedRows);
+        editRowButton.setEnabled(schemaEditable && selectedRows.size() == 1);
+        deleteRowButton.setEnabled(schemaEditable && !selectedRows.isEmpty());
     }
 
     private void showRowDialog(boolean isEdit) {
@@ -186,13 +196,15 @@ public class TableDataActivity extends AppCompatActivity {
             return;
         }
         int idIndex = findIdColumnIndex();
-        if (isEdit && (selectedRowIndex < 0 || selectedRowData == null)) {
-            Toast.makeText(this, "Выберите строку для изменения", Toast.LENGTH_SHORT).show();
-            return;
-        }
-        if (isEdit && idIndex < 0) {
-            Toast.makeText(this, "Редактирование невозможно: отсутствует столбец id", Toast.LENGTH_LONG).show();
-            return;
+        if (isEdit) {
+            if (selectedRows.size() != 1) {
+                Toast.makeText(this, "Выберите одну строку для изменения", Toast.LENGTH_SHORT).show();
+                return;
+            }
+            if (idIndex < 0) {
+                Toast.makeText(this, "Редактирование невозможно: отсутствует столбец id", Toast.LENGTH_LONG).show();
+                return;
+            }
         }
 
         LinearLayout container = new LinearLayout(this);
@@ -201,6 +213,7 @@ public class TableDataActivity extends AppCompatActivity {
         container.setPadding(padding, padding / 2, padding, 0);
 
         java.util.List<TextInputEditText> inputs = new java.util.ArrayList<>();
+        java.util.List<String> sourceRow = isEdit ? resolveSingleSelectedRow() : null;
         for (int i = 0; i < currentData.getColumns().size(); i++) {
             String column = currentData.getColumns().get(i);
             if ("id".equalsIgnoreCase(column)) {
@@ -210,8 +223,8 @@ public class TableDataActivity extends AppCompatActivity {
             layout.setHint(column);
             TextInputEditText editText = new TextInputEditText(layout.getContext());
             layout.addView(editText);
-            if (isEdit && selectedRowData != null && i < selectedRowData.size()) {
-                editText.setText(selectedRowData.get(i));
+            if (isEdit && sourceRow != null && i < sourceRow.size()) {
+                editText.setText(sourceRow.get(i));
             }
             inputs.add(editText);
             container.addView(layout);
@@ -253,11 +266,12 @@ public class TableDataActivity extends AppCompatActivity {
     }
 
     private void updateRow(int idIndex, ContentValues values) {
-        if (selectedRowData == null || idIndex >= selectedRowData.size()) {
+        java.util.List<String> row = resolveSingleSelectedRow();
+        if (row == null || idIndex >= row.size()) {
             Toast.makeText(this, "Невозможно обновить строку", Toast.LENGTH_SHORT).show();
             return;
         }
-        String idValue = selectedRowData.get(idIndex);
+        String idValue = row.get(idIndex);
         try {
             databaseManager.update(schemaName, tableName, values, "id = ?", new String[]{idValue});
             Toast.makeText(this, "Строка обновлена", Toast.LENGTH_SHORT).show();
@@ -270,32 +284,47 @@ public class TableDataActivity extends AppCompatActivity {
 
     private void confirmDelete() {
         int idIndex = findIdColumnIndex();
-        if (selectedRowData == null || selectedRowIndex < 0) {
-            Toast.makeText(this, "Выберите строку для удаления", Toast.LENGTH_SHORT).show();
+        if (selectedRows.isEmpty()) {
+            Toast.makeText(this, "Выберите строки для удаления", Toast.LENGTH_SHORT).show();
             return;
         }
         if (idIndex < 0) {
             Toast.makeText(this, "Удаление невозможно: отсутствует столбец id", Toast.LENGTH_LONG).show();
             return;
         }
-        String idValue = selectedRowData.get(idIndex);
         new MaterialAlertDialogBuilder(this)
-                .setTitle("Удалить строку?")
+                .setTitle("Удалить выбранные строки?")
                 .setMessage("Это действие необратимо.")
                 .setNegativeButton("Отмена", (dialog, which) -> dialog.dismiss())
-                .setPositiveButton("Удалить", (dialog, which) -> deleteRow(idValue))
+                .setPositiveButton("Удалить", (dialog, which) -> deleteSelectedRows(idIndex))
                 .show();
     }
 
-    private void deleteRow(String idValue) {
+    private void deleteSelectedRows(int idIndex) {
         try {
-            databaseManager.delete(schemaName, tableName, "id = ?", new String[]{idValue});
-            Toast.makeText(this, "Строка удалена", Toast.LENGTH_SHORT).show();
+            for (Integer rowIndex : selectedRows) {
+                java.util.List<String> row = currentData.getRows().get(rowIndex);
+                if (idIndex >= row.size()) continue;
+                String idValue = row.get(idIndex);
+                databaseManager.delete(schemaName, tableName, "id = ?", new String[]{idValue});
+            }
+            Toast.makeText(this, "Строки удалены", Toast.LENGTH_SHORT).show();
             loadTable();
         } catch (Exception e) {
             GlobalExceptionHandler.reportHandled(this, e);
-            Toast.makeText(this, "Не удалось удалить строку", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, "Не удалось удалить строки", Toast.LENGTH_SHORT).show();
         }
+    }
+
+    private java.util.List<String> resolveSingleSelectedRow() {
+        if (selectedRows.size() != 1 || currentData == null) {
+            return null;
+        }
+        int idx = selectedRows.iterator().next();
+        if (idx < 0 || idx >= currentData.getRows().size()) {
+            return null;
+        }
+        return currentData.getRows().get(idx);
     }
 
     private int findIdColumnIndex() {

--- a/app/src/main/java/com/amnesiawho/sqlviewer/TableDataActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/TableDataActivity.java
@@ -1,0 +1,121 @@
+package com.amnesiawho.sqlviewer;
+
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.activity.EdgeToEdge;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.amnesiawho.sqlviewer.core.exception.GlobalExceptionHandler;
+import com.amnesiawho.sqlviewer.data.db.DatabaseManager;
+import com.amnesiawho.sqlviewer.data.db.DbEngineType;
+import com.amnesiawho.sqlviewer.data.db.TableData;
+import com.amnesiawho.sqlviewer.ui.table.TableAdapter;
+import com.google.android.material.button.MaterialButtonToggleGroup;
+
+public class TableDataActivity extends AppCompatActivity {
+
+    private DatabaseManager databaseManager;
+    private TableAdapter tableAdapter;
+    private MaterialButtonToggleGroup limitToggleGroup;
+    private TextView tableTitle;
+    private TextView schemaLabel;
+    private TextView editabilityLabel;
+
+    private String schemaName;
+    private String tableName;
+    private boolean schemaEditable;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
+        setContentView(R.layout.activity_table_data);
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.tableDataRoot), (v, insets) -> {
+            Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+            return insets;
+        });
+
+        schemaName = getIntent().getStringExtra(TableSelectionActivity.EXTRA_SCHEMA_NAME);
+        schemaEditable = getIntent().getBooleanExtra(TableSelectionActivity.EXTRA_SCHEMA_EDITABLE, false);
+        tableName = getIntent().getStringExtra(TableSelectionActivity.EXTRA_SELECTED_TABLE);
+        String engineTypeName = getIntent().getStringExtra(TableSelectionActivity.EXTRA_ENGINE_TYPE);
+
+        if (schemaName == null || tableName == null || engineTypeName == null) {
+            Toast.makeText(this, "Не удалось открыть данные таблицы", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+
+        databaseManager = new DatabaseManager(this);
+        databaseManager.switchEngine(DbEngineType.valueOf(engineTypeName));
+
+        setupViews();
+        bindHeader();
+        loadTable();
+    }
+
+    private void setupViews() {
+        tableTitle = findViewById(R.id.tableNameTitle);
+        schemaLabel = findViewById(R.id.dataSchemaLabel);
+        editabilityLabel = findViewById(R.id.dataSchemaAccessLabel);
+        limitToggleGroup = findViewById(R.id.dataLimitToggleGroup);
+        Button reloadButton = findViewById(R.id.reloadTableButton);
+        Button rlsButton = findViewById(R.id.rlsButton);
+
+        RecyclerView recyclerView = findViewById(R.id.dataRecycler);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        tableAdapter = new TableAdapter(this);
+        recyclerView.setAdapter(tableAdapter);
+
+        limitToggleGroup.addOnButtonCheckedListener((group, checkedId, isChecked) -> {
+            if (isChecked) {
+                loadTable();
+            }
+        });
+
+        reloadButton.setOnClickListener(v -> loadTable());
+        rlsButton.setOnClickListener(v -> Toast.makeText(this, "Политики RLS скоро будут доступны", Toast.LENGTH_SHORT).show());
+    }
+
+    private void bindHeader() {
+        tableTitle.setText("Таблица: " + tableName);
+        schemaLabel.setText("Схема: " + schemaName);
+        editabilityLabel.setText(schemaEditable ? "Редактирование доступно" : "Только чтение");
+        editabilityLabel.setTextColor(getColor(schemaEditable ? R.color.supabase_on_surface : R.color.supabase_warning));
+    }
+
+    private int resolveLimit() {
+        int checkedId = limitToggleGroup.getCheckedButtonId();
+        if (checkedId == R.id.dataLimit1000) {
+            return 1000;
+        } else if (checkedId == R.id.dataLimit1500) {
+            return 1500;
+        } else if (checkedId == R.id.dataLimitUnlimited) {
+            return -1;
+        }
+        return 100;
+    }
+
+    private void loadTable() {
+        int limit = resolveLimit();
+        try {
+            TableData data = databaseManager.readTable(schemaName, tableName, limit);
+            tableAdapter.setData(data);
+            if (data.isEmpty()) {
+                Toast.makeText(this, "Данных нет или таблица пуста", Toast.LENGTH_SHORT).show();
+            }
+        } catch (Exception e) {
+            GlobalExceptionHandler.reportHandled(this, e);
+            Toast.makeText(this, "Не удалось загрузить данные таблицы", Toast.LENGTH_SHORT).show();
+        }
+    }
+}

--- a/app/src/main/java/com/amnesiawho/sqlviewer/TableSelectionActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/TableSelectionActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -19,6 +20,7 @@ import com.amnesiawho.sqlviewer.core.exception.GlobalExceptionHandler;
 import com.amnesiawho.sqlviewer.data.db.DatabaseManager;
 import com.amnesiawho.sqlviewer.data.db.DbEngineType;
 import com.amnesiawho.sqlviewer.ui.table.TableListAdapter;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.util.List;
 
@@ -121,7 +123,7 @@ public class TableSelectionActivity extends AppCompatActivity {
             Toast.makeText(this, "Редактирование недоступно для выбранной схемы", Toast.LENGTH_SHORT).show();
             return;
         }
-        Toast.makeText(this, "Функционал добавления таблиц будет доступен позже", Toast.LENGTH_SHORT).show();
+        showCreateTableDialog();
     }
 
     private void openTableScreen() {
@@ -135,5 +137,48 @@ public class TableSelectionActivity extends AppCompatActivity {
         intent.putExtra(EXTRA_ENGINE_TYPE, engineType.name());
         intent.putExtra(EXTRA_SELECTED_TABLE, selectedTable);
         startActivity(intent);
+    }
+
+    private void showCreateTableDialog() {
+        final EditText input = new EditText(this);
+        input.setHint("Название таблицы (латиница и _)");
+        input.setSingleLine(true);
+
+        new MaterialAlertDialogBuilder(this)
+                .setTitle("Новая таблица")
+                .setMessage("Будет создана таблица с полями id, name, created_at")
+                .setView(input)
+                .setNegativeButton("Отмена", (dialog, which) -> dialog.dismiss())
+                .setPositiveButton("Создать", (dialog, which) -> {
+                    String name = input.getText().toString().trim();
+                    createTable(name);
+                })
+                .show();
+    }
+
+    private void createTable(String tableName) {
+        if (tableName.isEmpty()) {
+            Toast.makeText(this, "Укажите название таблицы", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        if (!tableName.matches("[A-Za-z_][A-Za-z0-9_]*")) {
+            Toast.makeText(this, "Используйте латиницу, цифры и _ , начиная с буквы", Toast.LENGTH_LONG).show();
+            return;
+        }
+        try {
+            databaseManager.createTable(schemaName, tableName);
+            Toast.makeText(this, "Таблица создана: " + tableName, Toast.LENGTH_SHORT).show();
+            reloadTablesAndSelect(tableName);
+        } catch (Exception e) {
+            GlobalExceptionHandler.reportHandled(this, e);
+            Toast.makeText(this, "Не удалось создать таблицу", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void reloadTablesAndSelect(String tableName) throws Exception {
+        List<String> tables = databaseManager.listTables(schemaName);
+        tableListAdapter.setItems(tables);
+        tableListAdapter.setSelectedTable(tableName);
+        onTableSelected(tableName);
     }
 }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/TableSelectionActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/TableSelectionActivity.java
@@ -1,0 +1,139 @@
+package com.amnesiawho.sqlviewer;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.activity.EdgeToEdge;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.amnesiawho.sqlviewer.core.exception.GlobalExceptionHandler;
+import com.amnesiawho.sqlviewer.data.db.DatabaseManager;
+import com.amnesiawho.sqlviewer.data.db.DbEngineType;
+import com.amnesiawho.sqlviewer.ui.table.TableListAdapter;
+
+import java.util.List;
+
+public class TableSelectionActivity extends AppCompatActivity {
+
+    public static final String EXTRA_SCHEMA_NAME = "schema_name";
+    public static final String EXTRA_SCHEMA_EDITABLE = "schema_editable";
+    public static final String EXTRA_ENGINE_TYPE = "engine_type";
+
+    public static final String EXTRA_SELECTED_TABLE = "selected_table";
+
+    private DatabaseManager databaseManager;
+    private TableListAdapter tableListAdapter;
+    private TextView selectedSchemaLabel;
+    private TextView schemaAccessLabel;
+    private TextView selectedTableLabel;
+    private Button addTableButton;
+    private Button openTableButton;
+
+    private String schemaName;
+    private boolean schemaEditable;
+    private String selectedTable;
+    private DbEngineType engineType;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
+        setContentView(R.layout.activity_table_selection);
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.tableSelectionRoot), (v, insets) -> {
+            Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+            return insets;
+        });
+
+        schemaName = getIntent().getStringExtra(EXTRA_SCHEMA_NAME);
+        schemaEditable = getIntent().getBooleanExtra(EXTRA_SCHEMA_EDITABLE, false);
+        String engineTypeName = getIntent().getStringExtra(EXTRA_ENGINE_TYPE);
+
+        if (schemaName == null || engineTypeName == null) {
+            Toast.makeText(this, "Не удалось открыть список таблиц", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+
+        engineType = DbEngineType.valueOf(engineTypeName);
+        databaseManager = new DatabaseManager(this);
+        databaseManager.switchEngine(engineType);
+
+        setupViews();
+        bindSchemaInfo();
+        loadTables();
+    }
+
+    private void setupViews() {
+        selectedSchemaLabel = findViewById(R.id.selectedSchemaLabel);
+        schemaAccessLabel = findViewById(R.id.schemaAccessLabel);
+        selectedTableLabel = findViewById(R.id.selectedTableLabel);
+        addTableButton = findViewById(R.id.addTableButton);
+        openTableButton = findViewById(R.id.openTableButton);
+
+        RecyclerView tableListRecyclerView = findViewById(R.id.tableListRecycler);
+
+        tableListAdapter = new TableListAdapter(this::onTableSelected);
+        tableListRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        tableListRecyclerView.setAdapter(tableListAdapter);
+
+        openTableButton.setOnClickListener(v -> openTableScreen());
+        addTableButton.setOnClickListener(v -> handleAddTable());
+    }
+
+    private void bindSchemaInfo() {
+        selectedSchemaLabel.setText("Схема: " + schemaName);
+        schemaAccessLabel.setText(schemaEditable ? "Редактирование доступно" : "Только чтение");
+        schemaAccessLabel.setTextColor(getColor(schemaEditable ? R.color.supabase_on_surface : R.color.supabase_warning));
+        addTableButton.setVisibility(schemaEditable ? View.VISIBLE : View.GONE);
+        openTableButton.setEnabled(false);
+    }
+
+    private void loadTables() {
+        try {
+            List<String> tables = databaseManager.listTables(schemaName);
+            tableListAdapter.setItems(tables);
+            selectedTableLabel.setText("Таблица не выбрана");
+            openTableButton.setEnabled(false);
+        } catch (Exception e) {
+            GlobalExceptionHandler.reportHandled(this, e);
+            Toast.makeText(this, "Не удалось загрузить таблицы", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void onTableSelected(String tableName) {
+        selectedTable = tableName;
+        selectedTableLabel.setText("Выбрана таблица: " + tableName);
+        openTableButton.setEnabled(true);
+    }
+
+    private void handleAddTable() {
+        if (!schemaEditable) {
+            Toast.makeText(this, "Редактирование недоступно для выбранной схемы", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        Toast.makeText(this, "Функционал добавления таблиц будет доступен позже", Toast.LENGTH_SHORT).show();
+    }
+
+    private void openTableScreen() {
+        if (selectedTable == null) {
+            Toast.makeText(this, "Выберите таблицу", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        Intent intent = new Intent(this, TableDataActivity.class);
+        intent.putExtra(EXTRA_SCHEMA_NAME, schemaName);
+        intent.putExtra(EXTRA_SCHEMA_EDITABLE, schemaEditable);
+        intent.putExtra(EXTRA_ENGINE_TYPE, engineType.name());
+        intent.putExtra(EXTRA_SELECTED_TABLE, selectedTable);
+        startActivity(intent);
+    }
+}

--- a/app/src/main/java/com/amnesiawho/sqlviewer/TableSelectionActivity.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/TableSelectionActivity.java
@@ -29,6 +29,7 @@ public class TableSelectionActivity extends AppCompatActivity {
     public static final String EXTRA_SCHEMA_NAME = "schema_name";
     public static final String EXTRA_SCHEMA_EDITABLE = "schema_editable";
     public static final String EXTRA_ENGINE_TYPE = "engine_type";
+    public static final String EXTRA_CONNECTION_URL = "connection_url";
 
     public static final String EXTRA_SELECTED_TABLE = "selected_table";
 
@@ -44,6 +45,7 @@ public class TableSelectionActivity extends AppCompatActivity {
     private boolean schemaEditable;
     private String selectedTable;
     private DbEngineType engineType;
+    private String connectionUrl;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -59,6 +61,7 @@ public class TableSelectionActivity extends AppCompatActivity {
         schemaName = getIntent().getStringExtra(EXTRA_SCHEMA_NAME);
         schemaEditable = getIntent().getBooleanExtra(EXTRA_SCHEMA_EDITABLE, false);
         String engineTypeName = getIntent().getStringExtra(EXTRA_ENGINE_TYPE);
+        connectionUrl = getIntent().getStringExtra(EXTRA_CONNECTION_URL);
 
         if (schemaName == null || engineTypeName == null) {
             Toast.makeText(this, "Не удалось открыть список таблиц", Toast.LENGTH_SHORT).show();
@@ -68,7 +71,13 @@ public class TableSelectionActivity extends AppCompatActivity {
 
         engineType = DbEngineType.valueOf(engineTypeName);
         databaseManager = new DatabaseManager(this);
-        databaseManager.switchEngine(engineType);
+        try {
+            databaseManager.switchEngine(engineType, connectionUrl);
+        } catch (Exception e) {
+            Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
+            finish();
+            return;
+        }
 
         setupViews();
         bindSchemaInfo();
@@ -135,6 +144,7 @@ public class TableSelectionActivity extends AppCompatActivity {
         intent.putExtra(EXTRA_SCHEMA_NAME, schemaName);
         intent.putExtra(EXTRA_SCHEMA_EDITABLE, schemaEditable);
         intent.putExtra(EXTRA_ENGINE_TYPE, engineType.name());
+        intent.putExtra(EXTRA_CONNECTION_URL, connectionUrl);
         intent.putExtra(EXTRA_SELECTED_TABLE, selectedTable);
         startActivity(intent);
     }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseEngine.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseEngine.java
@@ -40,11 +40,11 @@ public interface DatabaseEngine {
      */
     void createTable(String schema, String tableName) throws Exception;
 
-    long insert(String tableName, ContentValues values) throws Exception;
+    long insert(String schema, String tableName, ContentValues values) throws Exception;
 
-    int update(String tableName, ContentValues values, String whereClause, String[] whereArgs) throws Exception;
+    int update(String schema, String tableName, ContentValues values, String whereClause, String[] whereArgs) throws Exception;
 
-    int delete(String tableName, String whereClause, String[] whereArgs) throws Exception;
+    int delete(String schema, String tableName, String whereClause, String[] whereArgs) throws Exception;
 
     void close();
 }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseEngine.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseEngine.java
@@ -32,6 +32,14 @@ public interface DatabaseEngine {
      */
     List<String> listTables(String schema) throws Exception;
 
+    /**
+     * Создает новую таблицу с базовыми колонками.
+     *
+     * @param schema    имя схемы/пространства, может быть null/пустым для движков без схем
+     * @param tableName имя таблицы
+     */
+    void createTable(String schema, String tableName) throws Exception;
+
     long insert(String tableName, ContentValues values) throws Exception;
 
     int update(String tableName, ContentValues values, String whereClause, String[] whereArgs) throws Exception;

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseEngine.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseEngine.java
@@ -2,6 +2,8 @@ package com.amnesiawho.sqlviewer.data.db;
 
 import android.content.ContentValues;
 
+import java.util.List;
+
 /**
  * Базовый контракт CRUD-операций для разных движков БД.
  */
@@ -14,10 +16,21 @@ public interface DatabaseEngine {
     /**
      * Чтение таблицы с ограничением по строкам.
      *
+     * @param schema    имя схемы или пространства, где находится таблица
      * @param tableName имя таблицы
      * @param limit     лимит строк, -1 если лимита нет
      */
-    TableData readTable(String tableName, int limit) throws Exception;
+    TableData readTable(String schema, String tableName, int limit) throws Exception;
+
+    /**
+     * Список доступных схем/пространств имен.
+     */
+    List<SchemaInfo> listSchemas() throws Exception;
+
+    /**
+     * Возвращает список таблиц в выбранной схеме.
+     */
+    List<String> listTables(String schema) throws Exception;
 
     long insert(String tableName, ContentValues values) throws Exception;
 

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseManager.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseManager.java
@@ -55,6 +55,18 @@ public class DatabaseManager {
         currentEngine.createTable(schema, tableName);
     }
 
+    public long insert(String schema, String tableName, android.content.ContentValues values) throws Exception {
+        return currentEngine.insert(schema, tableName, values);
+    }
+
+    public int update(String schema, String tableName, android.content.ContentValues values, String whereClause, String[] whereArgs) throws Exception {
+        return currentEngine.update(schema, tableName, values, whereClause, whereArgs);
+    }
+
+    public int delete(String schema, String tableName, String whereClause, String[] whereArgs) throws Exception {
+        return currentEngine.delete(schema, tableName, whereClause, whereArgs);
+    }
+
     public DbEngineType getCurrentType() {
         return currentType;
     }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseManager.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseManager.java
@@ -50,6 +50,10 @@ public class DatabaseManager {
         return currentEngine.listTables(schema);
     }
 
+    public void createTable(String schema, String tableName) throws Exception {
+        currentEngine.createTable(schema, tableName);
+    }
+
     public DbEngineType getCurrentType() {
         return currentType;
     }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseManager.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseManager.java
@@ -15,26 +15,27 @@ public class DatabaseManager {
 
     public DatabaseManager(Context context) {
         this.appContext = context.getApplicationContext();
-        switchEngine(DbEngineType.SQLITE);
+        switchEngine(DbEngineType.SQLITE, null);
     }
 
     /**
      * Переключение движка. Здесь можно добавить инициализацию JDBC драйверов при необходимости.
      */
-    public void switchEngine(DbEngineType type) {
+    public void switchEngine(DbEngineType type, String connectionUrl) {
         currentType = type;
         if (currentEngine != null) {
             currentEngine.close();
         }
         if (type == DbEngineType.SQLITE) {
-            currentEngine = new SQLiteEngine(appContext);
+            currentEngine = new SQLiteEngine(appContext, connectionUrl);
         } else {
-            currentEngine = new StubEngine(type);
+            throw new UnsupportedOperationException("Подключение к " + type.getTitle() + " пока не поддержано — требуется реальный драйвер");
         }
         try {
             currentEngine.connect();
         } catch (Exception e) {
             GlobalExceptionHandler.reportHandled(appContext, e);
+            throw new IllegalStateException("Не удалось подключиться к базе: " + e.getMessage(), e);
         }
     }
 

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseManager.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/DatabaseManager.java
@@ -38,8 +38,16 @@ public class DatabaseManager {
         }
     }
 
-    public TableData readTable(String tableName, int limit) throws Exception {
-        return currentEngine.readTable(tableName, limit);
+    public TableData readTable(String schema, String tableName, int limit) throws Exception {
+        return currentEngine.readTable(schema, tableName, limit);
+    }
+
+    public java.util.List<SchemaInfo> listSchemas() throws Exception {
+        return currentEngine.listSchemas();
+    }
+
+    public java.util.List<String> listTables(String schema) throws Exception {
+        return currentEngine.listTables(schema);
     }
 
     public DbEngineType getCurrentType() {

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SQLiteEngine.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SQLiteEngine.java
@@ -180,18 +180,21 @@ public class SQLiteEngine extends SQLiteOpenHelper implements DatabaseEngine {
     }
 
     @Override
-    public long insert(String tableName, ContentValues values) {
-        return getWritableDatabase().insert(tableName, null, values);
+    public long insert(String schema, String tableName, ContentValues values) {
+        String qualifiedName = buildQualifiedName(schema, tableName);
+        return getWritableDatabase().insert(qualifiedName, null, values);
     }
 
     @Override
-    public int update(String tableName, ContentValues values, String whereClause, String[] whereArgs) {
-        return getWritableDatabase().update(tableName, values, whereClause, whereArgs);
+    public int update(String schema, String tableName, ContentValues values, String whereClause, String[] whereArgs) {
+        String qualifiedName = buildQualifiedName(schema, tableName);
+        return getWritableDatabase().update(qualifiedName, values, whereClause, whereArgs);
     }
 
     @Override
-    public int delete(String tableName, String whereClause, String[] whereArgs) {
-        return getWritableDatabase().delete(tableName, whereClause, whereArgs);
+    public int delete(String schema, String tableName, String whereClause, String[] whereArgs) {
+        String qualifiedName = buildQualifiedName(schema, tableName);
+        return getWritableDatabase().delete(qualifiedName, whereClause, whereArgs);
     }
 
     @Override

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SQLiteEngine.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SQLiteEngine.java
@@ -18,9 +18,12 @@ public class SQLiteEngine extends SQLiteOpenHelper implements DatabaseEngine {
     private static final String DB_NAME = "sqlviewer_local.db";
     private static final int DB_VERSION = 1;
     private static final String DEMO_TABLE = "demo_users";
+    private final String customPath;
+    private SQLiteDatabase externalDb;
 
-    public SQLiteEngine(Context context) {
-        super(context, DB_NAME, null, DB_VERSION);
+    public SQLiteEngine(Context context, String connectionUrl) {
+        super(context, resolveDbName(connectionUrl), null, DB_VERSION);
+        this.customPath = resolveCustomPath(connectionUrl);
     }
 
     @Override
@@ -62,8 +65,16 @@ public class SQLiteEngine extends SQLiteOpenHelper implements DatabaseEngine {
 
     @Override
     public void connect() {
-        // Инициализация базы. SQLiteOpenHelper сам управляет соединением.
-        getWritableDatabase();
+        if (customPath != null) {
+            java.io.File dbFile = new java.io.File(customPath);
+            if (!dbFile.exists()) {
+                throw new IllegalArgumentException("База данных не найдена по пути: " + customPath);
+            }
+            externalDb = SQLiteDatabase.openDatabase(dbFile.getPath(), null, SQLiteDatabase.OPEN_READWRITE);
+        } else {
+            // Инициализация базы. SQLiteOpenHelper сам управляет соединением.
+            getWritableDatabase();
+        }
     }
 
     @Override
@@ -185,7 +196,21 @@ public class SQLiteEngine extends SQLiteOpenHelper implements DatabaseEngine {
 
     @Override
     public void close() {
-        super.close();
+        if (externalDb != null && externalDb.isOpen()) {
+            externalDb.close();
+        } else {
+            super.close();
+        }
+    }
+
+    @Override
+    public SQLiteDatabase getReadableDatabase() {
+        return externalDb != null ? externalDb : super.getReadableDatabase();
+    }
+
+    @Override
+    public SQLiteDatabase getWritableDatabase() {
+        return externalDb != null ? externalDb : super.getWritableDatabase();
     }
 
     private void validateTableName(String tableName) {
@@ -205,5 +230,30 @@ public class SQLiteEngine extends SQLiteOpenHelper implements DatabaseEngine {
             return "temp." + tableName;
         }
         return schema + "." + tableName;
+    }
+
+    private static String resolveDbName(String connectionUrl) {
+        if (connectionUrl == null || connectionUrl.trim().isEmpty()) {
+            return DB_NAME;
+        }
+        java.net.URI uri = java.net.URI.create(connectionUrl.trim());
+        String path = uri.getPath();
+        if (path == null || path.isEmpty() || "/".equals(path)) {
+            return DB_NAME;
+        }
+        String fileName = new java.io.File(path).getName();
+        return fileName.isEmpty() ? DB_NAME : fileName;
+    }
+
+    private static String resolveCustomPath(String connectionUrl) {
+        if (connectionUrl == null || connectionUrl.trim().isEmpty()) {
+            return null;
+        }
+        java.net.URI uri = java.net.URI.create(connectionUrl.trim());
+        String path = uri.getPath();
+        if (path == null || path.isEmpty() || "/".equals(path)) {
+            return null;
+        }
+        return path;
     }
 }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SQLiteEngine.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SQLiteEngine.java
@@ -67,7 +67,7 @@ public class SQLiteEngine extends SQLiteOpenHelper implements DatabaseEngine {
     }
 
     @Override
-    public TableData readTable(String tableName, int limit) {
+    public TableData readTable(String schema, String tableName, int limit) {
         List<String> columns = new ArrayList<>();
         List<List<String>> rows = new ArrayList<>();
 
@@ -100,6 +100,60 @@ public class SQLiteEngine extends SQLiteOpenHelper implements DatabaseEngine {
             }
         }
         return new TableData(columns, rows);
+    }
+
+    @Override
+    public List<SchemaInfo> listSchemas() {
+        List<SchemaInfo> schemas = new ArrayList<>();
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor cursor = db.rawQuery("PRAGMA database_list;", null);
+        try {
+            int nameIndex = cursor.getColumnIndexOrThrow("name");
+            while (cursor.moveToNext()) {
+                String name = cursor.getString(nameIndex);
+                boolean editable = "main".equalsIgnoreCase(name);
+                schemas.add(new SchemaInfo(name, editable));
+            }
+        } finally {
+            cursor.close();
+        }
+
+        if (schemas.isEmpty()) {
+            schemas.add(new SchemaInfo("main", true));
+            schemas.add(new SchemaInfo("temp", false));
+        }
+        return schemas;
+    }
+
+    @Override
+    public List<String> listTables(String schema) {
+        List<String> tables = new ArrayList<>();
+        SQLiteDatabase db = getReadableDatabase();
+        String masterTable;
+        if (schema == null || schema.isEmpty()) {
+            masterTable = "sqlite_master";
+        } else if ("temp".equalsIgnoreCase(schema)) {
+            masterTable = "sqlite_temp_master";
+        } else {
+            masterTable = schema + ".sqlite_master";
+        }
+        Cursor cursor = db.rawQuery(
+                "SELECT name FROM " + masterTable + " WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name;",
+                null
+        );
+        try {
+            int nameIndex = cursor.getColumnIndexOrThrow("name");
+            while (cursor.moveToNext()) {
+                tables.add(cursor.getString(nameIndex));
+            }
+        } finally {
+            cursor.close();
+        }
+
+        if (tables.isEmpty()) {
+            tables.add(DEMO_TABLE);
+        }
+        return tables;
     }
 
     @Override

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SQLiteEngine.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SQLiteEngine.java
@@ -157,6 +157,18 @@ public class SQLiteEngine extends SQLiteOpenHelper implements DatabaseEngine {
     }
 
     @Override
+    public void createTable(String schema, String tableName) {
+        validateTableName(tableName);
+        String qualifiedName = buildQualifiedName(schema, tableName);
+        SQLiteDatabase db = getWritableDatabase();
+        db.execSQL("CREATE TABLE IF NOT EXISTS " + qualifiedName + " (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "name TEXT NOT NULL, " +
+                "created_at TEXT DEFAULT CURRENT_TIMESTAMP" +
+                ");");
+    }
+
+    @Override
     public long insert(String tableName, ContentValues values) {
         return getWritableDatabase().insert(tableName, null, values);
     }
@@ -174,5 +186,24 @@ public class SQLiteEngine extends SQLiteOpenHelper implements DatabaseEngine {
     @Override
     public void close() {
         super.close();
+    }
+
+    private void validateTableName(String tableName) {
+        if (tableName == null || tableName.isEmpty()) {
+            throw new IllegalArgumentException("Название таблицы не может быть пустым");
+        }
+        if (!tableName.matches("[A-Za-z_][A-Za-z0-9_]*")) {
+            throw new IllegalArgumentException("Используйте латинские буквы, цифры и подчёркивания, начиная с буквы");
+        }
+    }
+
+    private String buildQualifiedName(String schema, String tableName) {
+        if (schema == null || schema.isEmpty() || "main".equalsIgnoreCase(schema)) {
+            return tableName;
+        }
+        if ("temp".equalsIgnoreCase(schema)) {
+            return "temp." + tableName;
+        }
+        return schema + "." + tableName;
     }
 }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SchemaInfo.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/SchemaInfo.java
@@ -1,0 +1,22 @@
+package com.amnesiawho.sqlviewer.data.db;
+
+/**
+ * Модель описания схемы/пространства имён.
+ */
+public class SchemaInfo {
+    private final String name;
+    private final boolean editable;
+
+    public SchemaInfo(String name, boolean editable) {
+        this.name = name;
+        this.editable = editable;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isEditable() {
+        return editable;
+    }
+}

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/StubEngine.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/StubEngine.java
@@ -4,7 +4,9 @@ import android.content.ContentValues;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Заглушка для движков, требующих отдельного драйвера. Дает единое сообщение, чтобы UI не падал.
@@ -13,9 +15,13 @@ public class StubEngine implements DatabaseEngine {
 
     private final DbEngineType type;
     private boolean connected = false;
+    private final Map<String, List<String>> schemaTables = new HashMap<>();
 
     public StubEngine(DbEngineType type) {
         this.type = type;
+        schemaTables.put("sandbox", new ArrayList<>(Collections.singletonList("draft_table")));
+        schemaTables.put("public", new ArrayList<>(java.util.Arrays.asList("users", "events", "metrics")));
+        schemaTables.put("analytics", new ArrayList<>(Collections.singletonList("reports")));
     }
 
     @Override
@@ -44,14 +50,24 @@ public class StubEngine implements DatabaseEngine {
 
     @Override
     public List<String> listTables(String schema) {
-        if ("sandbox".equalsIgnoreCase(schema)) {
-            return Collections.singletonList("draft_table");
+        String key = schema == null ? "" : schema.toLowerCase();
+        List<String> tables = schemaTables.get(key);
+        if (tables != null) {
+            return new ArrayList<>(tables);
         }
-        List<String> tables = new ArrayList<>();
-        tables.add("users");
-        tables.add("events");
-        tables.add("metrics");
-        return tables;
+        return new ArrayList<>(Collections.singletonList("example_table"));
+    }
+
+    @Override
+    public void createTable(String schema, String tableName) {
+        if (tableName == null || tableName.isEmpty()) {
+            throw new IllegalArgumentException("Название таблицы не может быть пустым");
+        }
+        String key = schema == null ? "" : schema.toLowerCase();
+        List<String> tables = schemaTables.computeIfAbsent(key, s -> new ArrayList<>());
+        if (!tables.contains(tableName)) {
+            tables.add(tableName);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/StubEngine.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/StubEngine.java
@@ -71,17 +71,17 @@ public class StubEngine implements DatabaseEngine {
     }
 
     @Override
-    public long insert(String tableName, ContentValues values) {
+    public long insert(String schema, String tableName, ContentValues values) {
         throw new UnsupportedOperationException("CRUD недоступен для движка " + type.getTitle());
     }
 
     @Override
-    public int update(String tableName, ContentValues values, String whereClause, String[] whereArgs) {
+    public int update(String schema, String tableName, ContentValues values, String whereClause, String[] whereArgs) {
         throw new UnsupportedOperationException("CRUD недоступен для движка " + type.getTitle());
     }
 
     @Override
-    public int delete(String tableName, String whereClause, String[] whereArgs) {
+    public int delete(String schema, String tableName, String whereClause, String[] whereArgs) {
         throw new UnsupportedOperationException("CRUD недоступен для движка " + type.getTitle());
     }
 

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/StubEngine.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/StubEngine.java
@@ -25,12 +25,33 @@ public class StubEngine implements DatabaseEngine {
     }
 
     @Override
-    public TableData readTable(String tableName, int limit) {
+    public TableData readTable(String schema, String tableName, int limit) {
         // Возвращаем информативную таблицу, чтобы пользователь понимал, что нужно подключить драйвер.
         List<String> columns = Collections.singletonList("Движок " + type.getTitle());
         List<List<String>> rows = new ArrayList<>();
         rows.add(Collections.singletonList("Добавьте драйвер и реальное подключение, чтобы читать таблицу '" + tableName + "'."));
         return new TableData(columns, rows);
+    }
+
+    @Override
+    public List<SchemaInfo> listSchemas() {
+        List<SchemaInfo> schemas = new ArrayList<>();
+        schemas.add(new SchemaInfo("public", false));
+        schemas.add(new SchemaInfo("sandbox", true));
+        schemas.add(new SchemaInfo("analytics", false));
+        return schemas;
+    }
+
+    @Override
+    public List<String> listTables(String schema) {
+        if ("sandbox".equalsIgnoreCase(schema)) {
+            return Collections.singletonList("draft_table");
+        }
+        List<String> tables = new ArrayList<>();
+        tables.add("users");
+        tables.add("events");
+        tables.add("metrics");
+        return tables;
     }
 
     @Override

--- a/app/src/main/java/com/amnesiawho/sqlviewer/data/db/UrlEngineResolver.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/data/db/UrlEngineResolver.java
@@ -1,0 +1,60 @@
+package com.amnesiawho.sqlviewer.data.db;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+
+/**
+ * Утилита для определения движка базы данных по URL.
+ */
+public final class UrlEngineResolver {
+
+    private UrlEngineResolver() {
+    }
+
+    /**
+     * Определяет движок по схеме URL. Поддерживает JDBC префикс.
+     *
+     * @param url строка подключения
+     * @return тип движка
+     * @throws IllegalArgumentException если схема не распознана или URL некорректен
+     */
+    public static DbEngineType resolve(String url) {
+        if (url == null || url.trim().isEmpty()) {
+            throw new IllegalArgumentException("URL подключения не должен быть пустым");
+        }
+        String normalized = url.trim();
+        if (normalized.toLowerCase(Locale.ROOT).startsWith("jdbc:")) {
+            normalized = normalized.substring(5);
+        }
+        URI uri;
+        try {
+            uri = new URI(normalized);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Некорректный формат URL: " + e.getMessage());
+        }
+
+        String scheme = uri.getScheme();
+        if (scheme == null || scheme.isEmpty()) {
+            throw new IllegalArgumentException("URL должен содержать схему (например, sqlite, postgres)");
+        }
+
+        switch (scheme.toLowerCase(Locale.ROOT)) {
+            case "sqlite":
+                return DbEngineType.SQLITE;
+            case "mysql":
+            case "mariadb":
+                return DbEngineType.MYSQL;
+            case "postgres":
+            case "postgresql":
+                return DbEngineType.POSTGRESQL;
+            case "sqlserver":
+            case "mssql":
+                return DbEngineType.SQLSERVER;
+            case "oracle":
+                return DbEngineType.ORACLE;
+            default:
+                throw new IllegalArgumentException("Неизвестная схема URL: " + scheme);
+        }
+    }
+}

--- a/app/src/main/java/com/amnesiawho/sqlviewer/ui/schema/SchemaAdapter.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/ui/schema/SchemaAdapter.java
@@ -1,0 +1,95 @@
+package com.amnesiawho.sqlviewer.ui.schema;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.amnesiawho.sqlviewer.R;
+import com.amnesiawho.sqlviewer.data.db.SchemaInfo;
+import com.google.android.material.card.MaterialCardView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SchemaAdapter extends RecyclerView.Adapter<SchemaAdapter.SchemaViewHolder> {
+
+    public interface OnSchemaClickListener {
+        void onSchemaClick(SchemaInfo schemaInfo);
+    }
+
+    private final List<SchemaInfo> items = new ArrayList<>();
+    private final OnSchemaClickListener listener;
+    private String selectedSchema;
+
+    public SchemaAdapter(OnSchemaClickListener listener) {
+        this.listener = listener;
+    }
+
+    public void setItems(List<SchemaInfo> schemas) {
+        items.clear();
+        items.addAll(schemas);
+        notifyDataSetChanged();
+    }
+
+    public void setSelectedSchema(String schema) {
+        this.selectedSchema = schema;
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public SchemaViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_schema, parent, false);
+        return new SchemaViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull SchemaViewHolder holder, int position) {
+        SchemaInfo info = items.get(position);
+        holder.bind(info, info.getName().equals(selectedSchema), listener);
+    }
+
+    @Override
+    public int getItemCount() {
+        return items.size();
+    }
+
+    static class SchemaViewHolder extends RecyclerView.ViewHolder {
+
+        private final TextView nameView;
+        private final TextView modeView;
+        private final MaterialCardView cardView;
+
+        SchemaViewHolder(@NonNull View itemView) {
+            super(itemView);
+            cardView = (MaterialCardView) itemView;
+            nameView = itemView.findViewById(R.id.schemaName);
+            modeView = itemView.findViewById(R.id.schemaMode);
+        }
+
+        void bind(SchemaInfo info, boolean isSelected, OnSchemaClickListener listener) {
+            nameView.setText(info.getName());
+            modeView.setText(info.isEditable() ? "Редактируемая" : "Только чтение");
+
+            int strokeColor = ContextCompat.getColor(itemView.getContext(),
+                    isSelected ? R.color.supabase_primary : R.color.supabase_border);
+            int background = ContextCompat.getColor(itemView.getContext(),
+                    info.isEditable() ? R.color.supabase_surface : R.color.supabase_surface_high);
+
+            cardView.setStrokeColor(strokeColor);
+            cardView.setCardBackgroundColor(background);
+            cardView.setCardElevation(isSelected ? 6f : 2f);
+
+            int modeColor = ContextCompat.getColor(itemView.getContext(),
+                    info.isEditable() ? R.color.supabase_on_surface : R.color.supabase_warning);
+            modeView.setTextColor(modeColor);
+
+            itemView.setOnClickListener(v -> listener.onSchemaClick(info));
+        }
+    }
+}

--- a/app/src/main/java/com/amnesiawho/sqlviewer/ui/table/TableAdapter.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/ui/table/TableAdapter.java
@@ -30,10 +30,10 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
     private final LayoutInflater inflater;
     private final List<List<String>> rows = new ArrayList<>();
     private List<String> columns = new ArrayList<>();
-    private final OnRowClickListener listener;
+    private final OnRowSelectListener listener;
     private int selectedRowIndex = -1;
 
-    public TableAdapter(Context context, OnRowClickListener listener) {
+    public TableAdapter(Context context, OnRowSelectListener listener) {
         this.inflater = LayoutInflater.from(context);
         this.listener = listener;
     }
@@ -89,15 +89,20 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
             rowContainer = itemView.findViewById(R.id.rowContainer);
         }
 
-        void bind(List<String> data, boolean isHeader, boolean isEvenRow, boolean isSelected, OnRowClickListener listener, int rowIndex) {
+        void bind(List<String> data, boolean isHeader, boolean isEvenRow, boolean isSelected, OnRowSelectListener listener, int rowIndex) {
             rowContainer.removeAllViews();
             for (String cell : data) {
                 TextView textView = createCell(rowContainer.getContext(), cell, isHeader, isEvenRow, isSelected);
                 rowContainer.addView(textView);
             }
             if (!isHeader && listener != null) {
-                itemView.setOnClickListener(v -> listener.onRowClick(rowIndex, data));
+                itemView.setOnLongClickListener(v -> {
+                    listener.onRowSelect(rowIndex, data);
+                    return true;
+                });
+                itemView.setOnClickListener(null);
             } else {
+                itemView.setOnLongClickListener(null);
                 itemView.setOnClickListener(null);
             }
         }
@@ -124,7 +129,7 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
         }
     }
 
-    public interface OnRowClickListener {
-        void onRowClick(int rowIndex, List<String> rowData);
+    public interface OnRowSelectListener {
+        void onRowSelect(int rowIndex, List<String> rowData);
     }
 }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/ui/table/TableAdapter.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/ui/table/TableAdapter.java
@@ -30,15 +30,24 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
     private final LayoutInflater inflater;
     private final List<List<String>> rows = new ArrayList<>();
     private List<String> columns = new ArrayList<>();
+    private final OnRowClickListener listener;
+    private int selectedRowIndex = -1;
 
-    public TableAdapter(Context context) {
+    public TableAdapter(Context context, OnRowClickListener listener) {
         this.inflater = LayoutInflater.from(context);
+        this.listener = listener;
     }
 
     public void setData(TableData data) {
         columns = new ArrayList<>(data.getColumns());
         rows.clear();
         rows.addAll(data.getRows());
+        selectedRowIndex = -1;
+        notifyDataSetChanged();
+    }
+
+    public void setSelectedRowIndex(int index) {
+        selectedRowIndex = index;
         notifyDataSetChanged();
     }
 
@@ -58,7 +67,13 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
     public void onBindViewHolder(@NonNull RowViewHolder holder, int position) {
         boolean isHeader = position == 0;
         boolean isEvenRow = position % 2 == 0;
-        holder.bind(position == 0 ? columns : rows.get(position - 1), isHeader, isEvenRow);
+        boolean isSelected = !isHeader && (position - 1) == selectedRowIndex;
+        holder.bind(position == 0 ? columns : rows.get(position - 1),
+                isHeader,
+                isEvenRow,
+                isSelected,
+                listener,
+                isHeader ? -1 : position - 1);
     }
 
     @Override
@@ -74,15 +89,20 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
             rowContainer = itemView.findViewById(R.id.rowContainer);
         }
 
-        void bind(List<String> data, boolean isHeader, boolean isEvenRow) {
+        void bind(List<String> data, boolean isHeader, boolean isEvenRow, boolean isSelected, OnRowClickListener listener, int rowIndex) {
             rowContainer.removeAllViews();
             for (String cell : data) {
-                TextView textView = createCell(rowContainer.getContext(), cell, isHeader, isEvenRow);
+                TextView textView = createCell(rowContainer.getContext(), cell, isHeader, isEvenRow, isSelected);
                 rowContainer.addView(textView);
+            }
+            if (!isHeader && listener != null) {
+                itemView.setOnClickListener(v -> listener.onRowClick(rowIndex, data));
+            } else {
+                itemView.setOnClickListener(null);
             }
         }
 
-        private TextView createCell(Context context, String text, boolean isHeader, boolean isEvenRow) {
+        private TextView createCell(Context context, String text, boolean isHeader, boolean isEvenRow, boolean isSelected) {
             TextView textView = new TextView(context);
             textView.setText(text);
             textView.setPadding(24, 16, 24, 16);
@@ -92,7 +112,7 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
             // Подбираем фон и цвета текста под тёмную тему Supabase
             int backgroundColor = ContextCompat.getColor(context, isHeader
                     ? R.color.supabase_surface_high
-                    : isEvenRow ? R.color.supabase_surface : R.color.supabase_surface_alt);
+                    : isSelected ? R.color.supabase_primary_tint : isEvenRow ? R.color.supabase_surface : R.color.supabase_surface_alt);
             int textColor = ContextCompat.getColor(context, R.color.supabase_on_surface);
             textView.setBackgroundColor(backgroundColor);
             textView.setTextColor(textColor);
@@ -102,5 +122,9 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
             textView.setLayoutParams(params);
             return textView;
         }
+    }
+
+    public interface OnRowClickListener {
+        void onRowClick(int rowIndex, List<String> rowData);
     }
 }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/ui/table/TableAdapter.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/ui/table/TableAdapter.java
@@ -31,6 +31,7 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
     private final List<List<String>> rows = new ArrayList<>();
     private List<String> columns = new ArrayList<>();
     private final OnRowSelectListener listener;
+    private final java.util.Set<Integer> selectedRows = new java.util.HashSet<>();
     private int selectedRowIndex = -1;
 
     public TableAdapter(Context context, OnRowSelectListener listener) {
@@ -46,8 +47,10 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
         notifyDataSetChanged();
     }
 
-    public void setSelectedRowIndex(int index) {
-        selectedRowIndex = index;
+    public void setSelection(java.util.Set<Integer> selection) {
+        selectedRows.clear();
+        selectedRows.addAll(selection);
+        selectedRowIndex = selection.isEmpty() ? -1 : selection.iterator().next();
         notifyDataSetChanged();
     }
 
@@ -67,7 +70,7 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
     public void onBindViewHolder(@NonNull RowViewHolder holder, int position) {
         boolean isHeader = position == 0;
         boolean isEvenRow = position % 2 == 0;
-        boolean isSelected = !isHeader && (position - 1) == selectedRowIndex;
+        boolean isSelected = !isHeader && selectedRows.contains(position - 1);
         holder.bind(position == 0 ? columns : rows.get(position - 1),
                 isHeader,
                 isEvenRow,
@@ -83,10 +86,12 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
 
     static class RowViewHolder extends RecyclerView.ViewHolder {
         private final LinearLayout rowContainer;
+        private final android.widget.CheckBox checkBox;
 
         RowViewHolder(@NonNull View itemView) {
             super(itemView);
             rowContainer = itemView.findViewById(R.id.rowContainer);
+            checkBox = itemView.findViewById(R.id.rowCheckbox);
         }
 
         void bind(List<String> data, boolean isHeader, boolean isEvenRow, boolean isSelected, OnRowSelectListener listener, int rowIndex) {
@@ -95,15 +100,19 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
                 TextView textView = createCell(rowContainer.getContext(), cell, isHeader, isEvenRow, isSelected);
                 rowContainer.addView(textView);
             }
-            if (!isHeader && listener != null) {
-                itemView.setOnLongClickListener(v -> {
-                    listener.onRowSelect(rowIndex, data);
-                    return true;
-                });
-                itemView.setOnClickListener(null);
+            if (isHeader) {
+                checkBox.setVisibility(View.INVISIBLE);
+                checkBox.setOnCheckedChangeListener(null);
             } else {
-                itemView.setOnLongClickListener(null);
-                itemView.setOnClickListener(null);
+                checkBox.setVisibility(View.VISIBLE);
+                checkBox.setOnCheckedChangeListener(null);
+                checkBox.setChecked(isSelected);
+                checkBox.setOnCheckedChangeListener((buttonView, checked) -> {
+                    if (listener != null) {
+                        listener.onRowSelect(rowIndex, checked);
+                    }
+                });
+                itemView.setOnClickListener(v -> checkBox.toggle());
             }
         }
 
@@ -130,6 +139,6 @@ public class TableAdapter extends RecyclerView.Adapter<TableAdapter.RowViewHolde
     }
 
     public interface OnRowSelectListener {
-        void onRowSelect(int rowIndex, List<String> rowData);
+        void onRowSelect(int rowIndex, boolean isSelected);
     }
 }

--- a/app/src/main/java/com/amnesiawho/sqlviewer/ui/table/TableListAdapter.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/ui/table/TableListAdapter.java
@@ -1,0 +1,81 @@
+package com.amnesiawho.sqlviewer.ui.table;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.amnesiawho.sqlviewer.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TableListAdapter extends RecyclerView.Adapter<TableListAdapter.TableViewHolder> {
+
+    public interface OnTableClickListener {
+        void onTableClick(String tableName);
+    }
+
+    private final List<String> items = new ArrayList<>();
+    private final OnTableClickListener listener;
+    private String selectedTable;
+
+    public TableListAdapter(OnTableClickListener listener) {
+        this.listener = listener;
+    }
+
+    public void setItems(List<String> tables) {
+        items.clear();
+        items.addAll(tables);
+        selectedTable = null;
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public TableViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_table_entry, parent, false);
+        return new TableViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull TableViewHolder holder, int position) {
+        String tableName = items.get(position);
+        holder.bind(tableName, tableName.equals(selectedTable), listener, () -> {
+            selectedTable = tableName;
+            notifyDataSetChanged();
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        return items.size();
+    }
+
+    static class TableViewHolder extends RecyclerView.ViewHolder {
+
+        private final TextView nameView;
+        private final View container;
+
+        TableViewHolder(@NonNull View itemView) {
+            super(itemView);
+            container = itemView.findViewById(R.id.tableItemContainer);
+            nameView = itemView.findViewById(R.id.tableItemName);
+        }
+
+        void bind(String tableName, boolean isSelected, OnTableClickListener listener, Runnable onSelected) {
+            nameView.setText(tableName);
+            int background = ContextCompat.getColor(itemView.getContext(),
+                    isSelected ? R.color.supabase_surface_high : R.color.supabase_surface);
+            container.setBackgroundColor(background);
+            itemView.setOnClickListener(v -> {
+                onSelected.run();
+                listener.onTableClick(tableName);
+            });
+        }
+    }
+}

--- a/app/src/main/java/com/amnesiawho/sqlviewer/ui/table/TableListAdapter.java
+++ b/app/src/main/java/com/amnesiawho/sqlviewer/ui/table/TableListAdapter.java
@@ -35,6 +35,11 @@ public class TableListAdapter extends RecyclerView.Adapter<TableListAdapter.Tabl
         notifyDataSetChanged();
     }
 
+    public void setSelectedTable(String tableName) {
+        selectedTable = tableName;
+        notifyDataSetChanged();
+    }
+
     @NonNull
     @Override
     public TableViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -44,27 +44,16 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Движок БД"
+                android:text="URL подключения"
                 android:textColor="@color/supabase_on_surface"
                 android:textStyle="bold" />
 
-            <Spinner
-                android:id="@+id/engineSpinner"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:backgroundTint="@color/supabase_surface_high"
-                android:entries="@array/engine_titles"
-                android:popupBackground="@color/supabase_surface_high"
-                android:textColor="@color/supabase_on_surface"
-                android:prompt="Выберите движок"
-                android:textColorHighlight="@color/supabase_primary" />
-
             <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/tableInputLayout"
+                android:id="@+id/urlInputLayout"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="Имя таблицы"
+                android:hint="Например, postgres://host:5432/db"
                 android:textColorHint="@color/supabase_on_surface"
                 app:boxStrokeColor="@color/supabase_border"
                 app:boxStrokeWidth="1dp"
@@ -72,111 +61,34 @@
                 app:boxBackgroundColor="@color/supabase_surface_alt">
 
                 <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/tableNameInput"
+                    android:id="@+id/urlInput"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="demo_users"
+                    android:autofillHints="username"
                     android:textColor="@color/supabase_on_surface"
                     android:textCursorDrawable="@null" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
-                android:id="@+id/limitLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                android:text="Лимит строк"
-                android:textColor="@color/supabase_on_surface" />
-
-            <com.google.android.material.button.MaterialButtonToggleGroup
-                android:id="@+id/limitToggleGroup"
+                android:id="@+id/engineLabel"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:checkedButton="@id/limit100"
-                app:singleSelection="true">
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/limit100"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="100"
-                    android:textColor="@color/supabase_on_surface"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:rippleColor="@color/supabase_primary" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/limit1000"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="1000"
-                    android:textColor="@color/supabase_on_surface"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:rippleColor="@color/supabase_primary" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/limit1500"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="1500"
-                    android:textColor="@color/supabase_on_surface"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:rippleColor="@color/supabase_primary" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/limitNoLimit"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Без лимита"
-                    android:textColor="@color/supabase_on_surface"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:rippleColor="@color/supabase_primary" />
-            </com.google.android.material.button.MaterialButtonToggleGroup>
+                android:layout_marginTop="8dp"
+                android:textColor="@color/supabase_on_surface" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/loadButton"
+                android:id="@+id/connectButton"
                 style="@style/Widget.Material3.Button"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="12dp"
-                android:text="Показать данные"
+                android:text="Проверить подключение"
                 android:textAllCaps="false"
                 android:textColor="@color/supabase_on_primary"
                 app:backgroundTint="@color/supabase_primary"
                 app:cornerRadius="12dp"
                 app:iconTint="@color/supabase_on_primary" />
         </LinearLayout>
-
-    </com.google.android.material.card.MaterialCardView>
-
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/tableCard"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="16dp"
-        app:cardBackgroundColor="@color/supabase_surface_high"
-        app:cardCornerRadius="16dp"
-        app:cardElevation="0dp"
-        app:strokeColor="@color/supabase_border"
-        app:strokeWidth="1dp"
-        app:layout_constraintTop_toBottomOf="@id/controlsCard"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/tableRecycler"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:padding="12dp"
-            tools:listitem="@layout/item_table_row" />
 
     </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/activity_schema_selection.xml
+++ b/app/src/main/res/layout/activity_schema_selection.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/schemaSelectionRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/supabase_background"
+    android:padding="16dp"
+    tools:context=".SchemaSelectionActivity">
+
+    <TextView
+        android:id="@+id/schemaSelectionTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="Выбор схемы"
+        android:textAppearance="@style/TextAppearance.Material3.HeadlineSmall"
+        android:textColor="@color/supabase_on_background"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/schemaEngineLabel"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:gravity="center"
+        android:textColor="@color/supabase_on_background"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/schemaSelectionTitle" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/schemaSelectionCard"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:padding="16dp"
+        android:visibility="gone"
+        app:cardBackgroundColor="@color/supabase_surface"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="2dp"
+        app:strokeColor="@color/supabase_border"
+        app:strokeWidth="1dp"
+        app:layout_constraintTop_toBottomOf="@id/schemaEngineLabel"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Схемы"
+                android:textColor="@color/supabase_on_surface"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="Нередактируемые схемы подсвечены"
+                android:textColor="@color/supabase_warning"
+                android:textSize="13sp" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/schemaSelectionRecycler"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                tools:listitem="@layout/item_schema" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_table_data.xml
+++ b/app/src/main/res/layout/activity_table_data.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tableDataRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/supabase_background"
+    android:padding="16dp"
+    tools:context=".TableDataActivity">
+
+    <TextView
+        android:id="@+id/tableDataTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="Данные таблицы"
+        android:textAppearance="@style/TextAppearance.Material3.HeadlineSmall"
+        android:textColor="@color/supabase_on_background"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/tableDataHeaderCard"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:padding="16dp"
+        app:cardBackgroundColor="@color/supabase_surface"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="2dp"
+        app:strokeColor="@color/supabase_border"
+        app:strokeWidth="1dp"
+        app:layout_constraintTop_toBottomOf="@id/tableDataTitle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/tableNameTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/supabase_on_surface"
+                android:textStyle="bold"
+                android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/dataSchemaLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textColor="@color/supabase_on_surface"
+                android:textSize="14sp" />
+
+            <TextView
+                android:id="@+id/dataSchemaAccessLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textColor="@color/supabase_primary"
+                android:textSize="13sp" />
+
+            <com.google.android.material.button.MaterialButtonToggleGroup
+                android:id="@+id/dataLimitToggleGroup"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:checkedButton="@id/dataLimit100"
+                app:singleSelection="true">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/dataLimit100"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="100"
+                    android:textColor="@color/supabase_on_surface"
+                    app:backgroundTint="@color/supabase_surface_high"
+                    app:rippleColor="@color/supabase_primary" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/dataLimit1000"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="1000"
+                    android:textColor="@color/supabase_on_surface"
+                    app:backgroundTint="@color/supabase_surface_high"
+                    app:rippleColor="@color/supabase_primary" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/dataLimit1500"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="1500"
+                    android:textColor="@color/supabase_on_surface"
+                    app:backgroundTint="@color/supabase_surface_high"
+                    app:rippleColor="@color/supabase_primary" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/dataLimitUnlimited"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Без лимита"
+                    android:textColor="@color/supabase_on_surface"
+                    app:backgroundTint="@color/supabase_surface_high"
+                    app:rippleColor="@color/supabase_primary" />
+            </com.google.android.material.button.MaterialButtonToggleGroup>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:orientation="horizontal"
+                android:weightSum="3">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/reloadTableButton"
+                    style="@style/Widget.Material3.Button"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1.5"
+                    android:text="Обновить"
+                    android:textAllCaps="false"
+                    android:textColor="@color/supabase_on_primary"
+                    app:backgroundTint="@color/supabase_primary"
+                    app:cornerRadius="12dp"
+                    app:iconTint="@color/supabase_on_primary" />
+
+                <Space
+                    android:layout_width="12dp"
+                    android:layout_height="wrap_content" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/rlsButton"
+                    style="@style/Widget.Material3.Button"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1.5"
+                    android:text="RLS политики"
+                    android:textAllCaps="false"
+                    android:textColor="@color/supabase_on_primary"
+                    app:backgroundTint="@color/supabase_primary_dark"
+                    app:cornerRadius="12dp"
+                    app:iconTint="@color/supabase_on_primary" />
+            </LinearLayout>
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/tableDataCard"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="16dp"
+        app:cardBackgroundColor="@color/supabase_surface_high"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="0dp"
+        app:strokeColor="@color/supabase_border"
+        app:strokeWidth="1dp"
+        app:layout_constraintTop_toBottomOf="@id/tableDataHeaderCard"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/dataRecycler"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="12dp"
+            tools:listitem="@layout/item_table_row" />
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_table_data.xml
+++ b/app/src/main/res/layout/activity_table_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/tableDataRoot"
@@ -7,244 +7,243 @@
     android:layout_height="match_parent"
     android:background="@color/supabase_background"
     android:padding="16dp"
+    android:fillViewport="true"
     tools:context=".TableDataActivity">
 
-    <TextView
-        android:id="@+id/tableDataTitle"
-        android:layout_width="0dp"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="Данные таблицы"
-        android:textAppearance="@style/TextAppearance.Material3.HeadlineSmall"
-        android:textColor="@color/supabase_on_background"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:orientation="vertical">
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/tableDataHeaderCard"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:padding="16dp"
-        app:cardBackgroundColor="@color/supabase_surface"
-        app:cardCornerRadius="16dp"
-        app:cardElevation="2dp"
-        app:strokeColor="@color/supabase_border"
-        app:strokeWidth="1dp"
-        app:layout_constraintTop_toBottomOf="@id/tableDataTitle"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-
-        <LinearLayout
+        <TextView
+            android:id="@+id/tableDataTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:gravity="center"
+            android:text="Данные таблицы"
+            android:textAppearance="@style/TextAppearance.Material3.HeadlineSmall"
+            android:textColor="@color/supabase_on_background" />
 
-            <TextView
-                android:id="@+id/tableNameTitle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/supabase_on_surface"
-                android:textStyle="bold"
-                android:textSize="16sp" />
-
-            <TextView
-                android:id="@+id/dataSchemaLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:textColor="@color/supabase_on_surface"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/dataSchemaAccessLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:textColor="@color/supabase_primary"
-                android:textSize="13sp" />
-
-            <com.google.android.material.button.MaterialButtonToggleGroup
-                android:id="@+id/dataLimitToggleGroup"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                android:checkedButton="@id/dataLimit100"
-                app:singleSelection="true">
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/dataLimit100"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="100"
-                    android:textColor="@color/supabase_on_surface"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:rippleColor="@color/supabase_primary" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/dataLimit1000"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="1000"
-                    android:textColor="@color/supabase_on_surface"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:rippleColor="@color/supabase_primary" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/dataLimit1500"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="1500"
-                    android:textColor="@color/supabase_on_surface"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:rippleColor="@color/supabase_primary" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/dataLimitUnlimited"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Без лимита"
-                    android:textColor="@color/supabase_on_surface"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:rippleColor="@color/supabase_primary" />
-            </com.google.android.material.button.MaterialButtonToggleGroup>
-
-            <TextView
-                android:id="@+id/selectedRowLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                android:text="Строка не выбрана"
-                android:textColor="@color/supabase_on_surface"
-                android:textSize="13sp" />
-
-            <LinearLayout
-                android:id="@+id/crudButtonsRow"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:orientation="horizontal"
-                android:visibility="gone"
-                android:weightSum="3">
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/addRowButton"
-                    style="@style/Widget.Material3.Button"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Добавить"
-                    android:textAllCaps="false"
-                    android:textColor="@color/supabase_on_primary"
-                    app:backgroundTint="@color/supabase_primary"
-                    app:cornerRadius="12dp"
-                    app:iconTint="@color/supabase_on_primary" />
-
-                <Space
-                    android:layout_width="8dp"
-                    android:layout_height="wrap_content" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/editRowButton"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Изменить"
-                    android:textAllCaps="false"
-                    android:textColor="@color/supabase_on_surface"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:cornerRadius="12dp"
-                    app:iconTint="@color/supabase_on_surface" />
-
-                <Space
-                    android:layout_width="8dp"
-                    android:layout_height="wrap_content" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/deleteRowButton"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Удалить"
-                    android:textAllCaps="false"
-                    android:textColor="@color/supabase_warning"
-                    app:backgroundTint="@color/supabase_surface_high"
-                    app:cornerRadius="12dp"
-                    app:iconTint="@color/supabase_warning" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                android:orientation="horizontal"
-                android:weightSum="3">
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/reloadTableButton"
-                    style="@style/Widget.Material3.Button"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1.5"
-                    android:text="Обновить"
-                    android:textAllCaps="false"
-                    android:textColor="@color/supabase_on_primary"
-                    app:backgroundTint="@color/supabase_primary"
-                    app:cornerRadius="12dp"
-                    app:iconTint="@color/supabase_on_primary" />
-
-                <Space
-                    android:layout_width="12dp"
-                    android:layout_height="wrap_content" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/rlsButton"
-                    style="@style/Widget.Material3.Button"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1.5"
-                    android:text="RLS политики"
-                    android:textAllCaps="false"
-                    android:textColor="@color/supabase_on_primary"
-                    app:backgroundTint="@color/supabase_primary_dark"
-                    app:cornerRadius="12dp"
-                    app:iconTint="@color/supabase_on_primary" />
-            </LinearLayout>
-        </LinearLayout>
-    </com.google.android.material.card.MaterialCardView>
-
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/tableDataCard"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="16dp"
-        app:cardBackgroundColor="@color/supabase_surface_high"
-        app:cardCornerRadius="16dp"
-        app:cardElevation="0dp"
-        app:strokeColor="@color/supabase_border"
-        app:strokeWidth="1dp"
-        app:layout_constraintTop_toBottomOf="@id/tableDataHeaderCard"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/dataRecycler"
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/tableDataHeaderCard"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:padding="12dp"
-            tools:listitem="@layout/item_table_row" />
-    </com.google.android.material.card.MaterialCardView>
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:padding="16dp"
+            app:cardBackgroundColor="@color/supabase_surface"
+            app:cardCornerRadius="16dp"
+            app:cardElevation="2dp"
+            app:strokeColor="@color/supabase_border"
+            app:strokeWidth="1dp">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/tableNameTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/supabase_on_surface"
+                    android:textStyle="bold"
+                    android:textSize="16sp" />
+
+                <TextView
+                    android:id="@+id/dataSchemaLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:textColor="@color/supabase_on_surface"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:id="@+id/dataSchemaAccessLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:textColor="@color/supabase_primary"
+                    android:textSize="13sp" />
+
+                <com.google.android.material.button.MaterialButtonToggleGroup
+                    android:id="@+id/dataLimitToggleGroup"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:checkedButton="@id/dataLimit100"
+                    app:singleSelection="true">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/dataLimit100"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="100"
+                        android:textColor="@color/supabase_on_surface"
+                        app:backgroundTint="@color/supabase_surface_high"
+                        app:rippleColor="@color/supabase_primary" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/dataLimit1000"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="1000"
+                        android:textColor="@color/supabase_on_surface"
+                        app:backgroundTint="@color/supabase_surface_high"
+                        app:rippleColor="@color/supabase_primary" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/dataLimit1500"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="1500"
+                        android:textColor="@color/supabase_on_surface"
+                        app:backgroundTint="@color/supabase_surface_high"
+                        app:rippleColor="@color/supabase_primary" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/dataLimitUnlimited"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Без лимита"
+                        android:textColor="@color/supabase_on_surface"
+                        app:backgroundTint="@color/supabase_surface_high"
+                        app:rippleColor="@color/supabase_primary" />
+                </com.google.android.material.button.MaterialButtonToggleGroup>
+
+                <TextView
+                    android:id="@+id/selectedRowLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:text="Строки не выбраны"
+                    android:textColor="@color/supabase_on_surface"
+                    android:textSize="13sp" />
+
+                <LinearLayout
+                    android:id="@+id/crudButtonsRow"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:orientation="horizontal"
+                    android:visibility="gone"
+                    android:weightSum="3">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/addRowButton"
+                        style="@style/Widget.Material3.Button"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Добавить"
+                        android:textAllCaps="false"
+                        android:textColor="@color/supabase_on_primary"
+                        app:backgroundTint="@color/supabase_primary"
+                        app:cornerRadius="12dp"
+                        app:iconTint="@color/supabase_on_primary" />
+
+                    <Space
+                        android:layout_width="8dp"
+                        android:layout_height="wrap_content" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/editRowButton"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Изменить"
+                        android:textAllCaps="false"
+                        android:textColor="@color/supabase_on_surface"
+                        app:backgroundTint="@color/supabase_surface_high"
+                        app:cornerRadius="12dp"
+                        app:iconTint="@color/supabase_on_surface" />
+
+                    <Space
+                        android:layout_width="8dp"
+                        android:layout_height="wrap_content" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/deleteRowButton"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Удалить"
+                        android:textAllCaps="false"
+                        android:textColor="@color/supabase_warning"
+                        app:backgroundTint="@color/supabase_surface_high"
+                        app:cornerRadius="12dp"
+                        app:iconTint="@color/supabase_warning" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:orientation="horizontal"
+                    android:weightSum="3">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/reloadTableButton"
+                        style="@style/Widget.Material3.Button"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1.5"
+                        android:text="Обновить"
+                        android:textAllCaps="false"
+                        android:textColor="@color/supabase_on_primary"
+                        app:backgroundTint="@color/supabase_primary"
+                        app:cornerRadius="12dp"
+                        app:iconTint="@color/supabase_on_primary" />
+
+                    <Space
+                        android:layout_width="12dp"
+                        android:layout_height="wrap_content" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/rlsButton"
+                        style="@style/Widget.Material3.Button"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1.5"
+                        android:text="RLS политики"
+                        android:textAllCaps="false"
+                        android:textColor="@color/supabase_on_primary"
+                        app:backgroundTint="@color/supabase_primary_dark"
+                        app:cornerRadius="12dp"
+                        app:iconTint="@color/supabase_on_primary" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/tableDataCard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:cardBackgroundColor="@color/supabase_surface_high"
+            app:cardCornerRadius="16dp"
+            app:cardElevation="0dp"
+            app:strokeColor="@color/supabase_border"
+            app:strokeWidth="1dp">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/dataRecycler"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:nestedScrollingEnabled="false"
+                android:padding="12dp"
+                tools:listitem="@layout/item_table_row" />
+        </com.google.android.material.card.MaterialCardView>
+
+    </LinearLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/activity_table_data.xml
+++ b/app/src/main/res/layout/activity_table_data.xml
@@ -118,6 +118,72 @@
                     app:rippleColor="@color/supabase_primary" />
             </com.google.android.material.button.MaterialButtonToggleGroup>
 
+            <TextView
+                android:id="@+id/selectedRowLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="Строка не выбрана"
+                android:textColor="@color/supabase_on_surface"
+                android:textSize="13sp" />
+
+            <LinearLayout
+                android:id="@+id/crudButtonsRow"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:orientation="horizontal"
+                android:visibility="gone"
+                android:weightSum="3">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/addRowButton"
+                    style="@style/Widget.Material3.Button"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Добавить"
+                    android:textAllCaps="false"
+                    android:textColor="@color/supabase_on_primary"
+                    app:backgroundTint="@color/supabase_primary"
+                    app:cornerRadius="12dp"
+                    app:iconTint="@color/supabase_on_primary" />
+
+                <Space
+                    android:layout_width="8dp"
+                    android:layout_height="wrap_content" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/editRowButton"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Изменить"
+                    android:textAllCaps="false"
+                    android:textColor="@color/supabase_on_surface"
+                    app:backgroundTint="@color/supabase_surface_high"
+                    app:cornerRadius="12dp"
+                    app:iconTint="@color/supabase_on_surface" />
+
+                <Space
+                    android:layout_width="8dp"
+                    android:layout_height="wrap_content" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/deleteRowButton"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Удалить"
+                    android:textAllCaps="false"
+                    android:textColor="@color/supabase_warning"
+                    app:backgroundTint="@color/supabase_surface_high"
+                    app:cornerRadius="12dp"
+                    app:iconTint="@color/supabase_warning" />
+            </LinearLayout>
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_table_selection.xml
+++ b/app/src/main/res/layout/activity_table_selection.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tableSelectionRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/supabase_background"
+    android:padding="16dp"
+    tools:context=".TableSelectionActivity">
+
+    <TextView
+        android:id="@+id/tableSelectionTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="Выбор таблиц"
+        android:textAppearance="@style/TextAppearance.Material3.HeadlineSmall"
+        android:textColor="@color/supabase_on_background"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/tableSelectorCard"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:padding="16dp"
+        app:cardBackgroundColor="@color/supabase_surface"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="2dp"
+        app:strokeColor="@color/supabase_border"
+        app:strokeWidth="1dp"
+        app:layout_constraintTop_toBottomOf="@id/tableSelectionTitle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/selectedSchemaLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/supabase_on_surface"
+                android:textStyle="bold"
+                android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/schemaAccessLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textColor="@color/supabase_primary"
+                android:textSize="13sp" />
+
+            <TextView
+                android:id="@+id/selectedTableLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textColor="@color/supabase_on_surface"
+                android:textSize="14sp" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:orientation="horizontal"
+                android:weightSum="2">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/openTableButton"
+                    style="@style/Widget.Material3.Button"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Открыть таблицу"
+                    android:textAllCaps="false"
+                    android:textColor="@color/supabase_on_primary"
+                    app:backgroundTint="@color/supabase_primary"
+                    app:cornerRadius="12dp"
+                    app:iconTint="@color/supabase_on_primary" />
+
+                <Space
+                    android:layout_width="12dp"
+                    android:layout_height="wrap_content" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/addTableButton"
+                    style="@style/Widget.Material3.Button"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Добавить таблицу"
+                    android:textAllCaps="false"
+                    android:textColor="@color/supabase_on_primary"
+                    app:backgroundTint="@color/supabase_primary_dark"
+                    app:cornerRadius="12dp"
+                    app:iconTint="@color/supabase_on_primary" />
+            </LinearLayout>
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/tableListRecycler"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="16dp"
+        android:paddingEnd="4dp"
+        app:layout_constraintTop_toBottomOf="@id/tableSelectorCard"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:listitem="@layout/item_table_entry" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_schema.xml
+++ b/app/src/main/res/layout/item_schema.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
+    android:foreground="?attr/selectableItemBackground"
+    app:cardElevation="2dp"
+    app:cardCornerRadius="12dp"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/schemaName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/supabase_on_surface"
+            android:textStyle="bold"
+            android:textSize="16sp" />
+
+        <TextView
+            android:id="@+id/schemaMode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textColor="@color/supabase_primary"
+            android:textSize="13sp" />
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_table_entry.xml
+++ b/app/src/main/res/layout/item_table_entry.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/tableItemContainer"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/tableItemName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/supabase_on_surface"
+        android:textSize="15sp"
+        android:textStyle="bold" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_table_row.xml
+++ b/app/src/main/res/layout/item_table_row.xml
@@ -1,12 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<HorizontalScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:scrollbars="horizontal">
+    android:orientation="horizontal"
+    android:paddingEnd="8dp"
+    android:paddingStart="8dp">
 
-    <LinearLayout
-        android:id="@+id/rowContainer"
+    <CheckBox
+        android:id="@+id/rowCheckbox"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal" />
-</HorizontalScrollView>
+        android:focusable="false"
+        android:focusableInTouchMode="false" />
+
+    <HorizontalScrollView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:scrollbars="horizontal">
+
+        <LinearLayout
+            android:id="@+id/rowContainer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" />
+    </HorizontalScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,6 +11,7 @@
     <color name="supabase_on_background">#E5E7EB</color>
     <color name="supabase_on_surface">#D1D5DB</color>
     <color name="supabase_on_primary">#0A0F1F</color>
+    <color name="supabase_warning">#F59E0B</color>
 
     <color name="black" tools:ignore="UnusedResources">#FF000000</color>
     <color name="white" tools:ignore="UnusedResources">#FFFFFFFF</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,6 +12,7 @@
     <color name="supabase_on_surface">#D1D5DB</color>
     <color name="supabase_on_primary">#0A0F1F</color>
     <color name="supabase_warning">#F59E0B</color>
+    <color name="supabase_primary_tint">#233C32</color>
 
     <color name="black" tools:ignore="UnusedResources">#FF000000</color>
     <color name="white" tools:ignore="UnusedResources">#FFFFFFFF</color>


### PR DESCRIPTION
## Summary
- add a dedicated schema-selection screen so connection and schema browsing are separate steps
- adjust the main screen to focus on URL validation and launch the schema picker after a successful connection
- register the new activity and layout to reuse existing schema highlighting for read-only entries

## Testing
- Not run (Android tooling unavailable in container)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693b39580c60832fa783e8f5b52ebdf7)